### PR TITLE
Incorporate changes from upstream libreoffice-6.0.0.3

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,0 +1,3 @@
+{
+    "skip-arches": ["arm"]
+}

--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,0 @@
-{
-    "skip-arches": ["arm"]
-}

--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -10,12 +10,21 @@
     "build-options": {
         "env": {
             "CC": "/usr/lib/sdk/gcc7/bin/gcc",
-            "CXX": "/usr/lib/sdk/gcc7/bin/g++"
+            "CXX": "/usr/lib/sdk/gcc7/bin/g++",
+            "LD_LIBRARY_PATH": "/usr/lib/sdk/gcc7/lib"
         }
     },
     "command": "/app/libreoffice/program/soffice",
     "separate-locales": false,
     "modules": [
+        {
+            "name": "gcc7",
+            "buildsystem": "simple",
+            "build-commands": [
+                "mkdir -p /app/lib",
+                "cp -a /usr/lib/sdk/gcc7/lib/lib{gcc_s.so.1,stdc++.so.6*} /app/lib"
+            ]
+        },
         {
             "name": "openjdk",
             "buildsystem": "simple",

--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -22,7 +22,7 @@
             "buildsystem": "simple",
             "build-commands": [
                 "mkdir -p /app/lib",
-                "cp -a /usr/lib/sdk/gcc7/lib/lib{gcc_s.so.1,stdc++.so.6*} /app/lib"
+                "cp -d /usr/lib/sdk/gcc7/lib/lib{gcc_s.so.1,stdc++.so.6*} /app/lib"
             ]
         },
         {

--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -4,8 +4,15 @@
     "runtime-version": "3.24",
     "sdk": "org.gnome.Sdk",
     "sdk-extensions": [
+        "org.freedesktop.Sdk.Extension.gcc7",
         "org.freedesktop.Sdk.Extension.openjdk9"
     ],
+    "build-options": {
+        "env": {
+            "CC": "/usr/lib/sdk/gcc7/bin/gcc",
+            "CXX": "/usr/lib/sdk/gcc7/bin/g++"
+        }
+    },
     "command": "/app/libreoffice/program/soffice",
     "separate-locales": false,
     "modules": [

--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -23,7 +23,12 @@
                     "type": "git",
                     "url": "git://gerrit.libreoffice.org/core",
                     "branch": "libreoffice-6.0.0.3",
-                    "disable-fsckobjects": true
+                    "disable-fsckobjects": true,
+                    "disable-shallow-clone": true
+                },
+                {
+                    "commands": ["git cherry-pick -n 6e1e8225bea130c0e586029500cfe14130d5691c"],
+                    "type": "shell"
                 },
                 {
                     "type": "archive",

--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -3,17 +3,33 @@
     "runtime": "org.gnome.Platform",
     "runtime-version": "3.24",
     "sdk": "org.gnome.Sdk",
+    "sdk-extensions": [
+        "org.freedesktop.Sdk.Extension.openjdk9"
+    ],
     "command": "/app/libreoffice/program/soffice",
     "separate-locales": false,
     "modules": [
+        {
+            "name": "openjdk",
+            "buildsystem": "simple",
+            "build-commands": [
+                "/usr/lib/sdk/openjdk9/install.sh"
+            ]
+        },
         {
             "name": "libreoffice",
             "sources": [
                 {
                     "type": "git",
                     "url": "git://gerrit.libreoffice.org/core",
-                    "branch": "libreoffice-5.4.4.2",
+                    "branch": "libreoffice-6.0.0.3",
                     "disable-fsckobjects": true
+                },
+                {
+                    "type": "archive",
+                    "url": "http://www-us.apache.org/dist/ant/binaries/apache-ant-1.10.1-bin.tar.xz",
+                    "sha512": "8732ecfd96bcfde626260939f17fdb7e85700092ef69932b250e3572810cd53eaac24e1c72921d89900170804d27cc3100bee7c8b5159d0e5b64c3d79e07bec6",
+                    "dest": "ant"
                 },
                 {
                     "commands": [
@@ -22,22 +38,10 @@
                     "type": "shell"
                 },
                 {
-                    "url": "https://dev-www.libreoffice.org/src/4b87018f7fff1d054939d19920b751a0-collada2gltf-master-cb1d97788a.tar.bz2",
-                    "sha256": "b0adb8e71aef80751b999c9c055e419a625c4a05184e407aef2aee28752ad8cb",
+                    "url": "https://dev-www.libreoffice.org/src/pdfium-3235.tar.bz2",
+                    "sha256": "7dc0d33fc24b1612865f5e173d48800ba3f2db891c57e3f92b9d2ce56ffeb72f",
                     "type": "file",
-                    "dest-filename": "external/tarballs/4b87018f7fff1d054939d19920b751a0-collada2gltf-master-cb1d97788a.tar.bz2"
-                },
-                {
-                    "url": "https://dev-www.libreoffice.org/src/pdfium-3064.tar.bz2",
-                    "sha256": "ded806dc9e2a4005d8c0a6b7fcb232ab36221d72d9ff5b815e8244987299d883",
-                    "type": "file",
-                    "dest-filename": "external/tarballs/pdfium-3064.tar.bz2"
-                },
-                {
-                    "url": "https://dev-www.libreoffice.org/src/OpenCOLLADA-master-6509aa13af.tar.bz2",
-                    "sha256": "8f25d429237cde289a448c82a0a830791354ccce5ee40d77535642e46367d6c4",
-                    "type": "file",
-                    "dest-filename": "external/tarballs/OpenCOLLADA-master-6509aa13af.tar.bz2"
+                    "dest-filename": "external/tarballs/pdfium-3235.tar.bz2"
                 },
                 {
                     "url": "https://dev-www.libreoffice.org/src/0168229624cfac409e766913506961a8-ucpp-1.3.2.tar.gz",
@@ -46,10 +50,10 @@
                     "dest-filename": "external/tarballs/0168229624cfac409e766913506961a8-ucpp-1.3.2.tar.gz"
                 },
                 {
-                    "url": "https://dev-www.libreoffice.org/src/xmlsec1-1.2.24.tar.gz",
-                    "sha256": "99a8643f118bb1261a72162f83e2deba0f4f690893b4b90e1be4f708e8d481cc",
+                    "url": "https://dev-www.libreoffice.org/src/xmlsec1-1.2.25.tar.gz",
+                    "sha256": "967ca83edf25ccb5b48a3c4a09ad3405a63365576503bf34290a42de1b92fcd2",
                     "type": "file",
-                    "dest-filename": "external/tarballs/xmlsec1-1.2.24.tar.gz"
+                    "dest-filename": "external/tarballs/xmlsec1-1.2.25.tar.gz"
                 },
                 {
                     "url": "https://dev-www.libreoffice.org/src/368f114c078f94214a308a74c7e991bc-crosextrafonts-20130214.tar.gz",
@@ -124,10 +128,10 @@
                     "dest-filename": "external/tarballs/EmojiOneColor-SVGinOT-1.3.tar.gz"
                 },
                 {
-                    "url": "https://dev-www.libreoffice.org/src/boost_1_63_0.tar.bz2",
-                    "sha256": "beae2529f759f6b3bf3f4969a19c2e9d6f0c503edcb2de4a61d1428519fcb3b0",
+                    "url": "https://dev-www.libreoffice.org/src/boost_1_65_1.tar.bz2",
+                    "sha256": "9807a5d16566c57fd74fb522764e0b134a8bbe6b6e8967b83afefd30dcd3be81",
                     "type": "file",
-                    "dest-filename": "external/tarballs/boost_1_63_0.tar.bz2"
+                    "dest-filename": "external/tarballs/boost_1_65_1.tar.bz2"
                 },
                 {
                     "url": "https://dev-www.libreoffice.org/src/48d647fbd8ef8889e5a7f422c1bfda94-clucene-core-2.3.3.4.tar.gz",
@@ -160,10 +164,10 @@
                     "dest-filename": "external/tarballs/bae83fa5dc7f081768daace6e199adc3-glm-0.9.4.6-libreoffice.zip"
                 },
                 {
-                    "url": "https://dev-www.libreoffice.org/src/gpgme-1.8.0.tar.bz2",
-                    "sha256": "596097257c2ce22e747741f8ff3d7e24f6e26231fa198a41b2a072e62d1e5d33",
+                    "url": "https://dev-www.libreoffice.org/src/gpgme-1.9.0.tar.bz2",
+                    "sha256": "1b29fedb8bfad775e70eafac5b0590621683b2d9869db994568e6401f4034ceb",
                     "type": "file",
-                    "dest-filename": "external/tarballs/gpgme-1.8.0.tar.bz2"
+                    "dest-filename": "external/tarballs/gpgme-1.9.0.tar.bz2"
                 },
                 {
                     "url": "https://dev-www.libreoffice.org/src/libassuan-2.4.3.tar.bz2",
@@ -172,22 +176,22 @@
                     "dest-filename": "external/tarballs/libassuan-2.4.3.tar.bz2"
                 },
                 {
-                    "url": "https://dev-www.libreoffice.org/src/libgpg-error-1.26.tar.bz2",
-                    "sha256": "4c4bcbc90116932e3acd37b37812d8653b1b189c1904985898e860af818aee69",
+                    "url": "https://dev-www.libreoffice.org/src/libgpg-error-1.27.tar.bz2",
+                    "sha256": "4f93aac6fecb7da2b92871bb9ee33032be6a87b174f54abf8ddf0911a22d29d2",
                     "type": "file",
-                    "dest-filename": "external/tarballs/libgpg-error-1.26.tar.bz2"
+                    "dest-filename": "external/tarballs/libgpg-error-1.27.tar.bz2"
                 },
                 {
-                    "url": "https://dev-www.libreoffice.org/src/libabw-0.1.1.tar.bz2",
-                    "sha256": "7a3d3415cf82ab9894f601d1b3057c4615060304d5279efdec6275e01b96a199",
+                    "url": "https://dev-www.libreoffice.org/src/libabw-0.1.2.tar.xz",
+                    "sha256": "0b72944d5af81dda0a5c5803ee84cbac4b81441a4d767aa57029adc6744c2485",
                     "type": "file",
-                    "dest-filename": "external/tarballs/libabw-0.1.1.tar.bz2"
+                    "dest-filename": "external/tarballs/libabw-0.1.2.tar.xz"
                 },
                 {
-                    "url": "https://dev-www.libreoffice.org/src/libcdr-0.1.3.tar.bz2",
-                    "sha256": "5160bbbfefe52bd4880840fad2b07a512813e37bfaf8ccac062fca238f230f4d",
+                    "url": "https://dev-www.libreoffice.org/src/libcdr-0.1.4.tar.xz",
+                    "sha256": "e7a7e8b00a3df5798110024d7061fe9d1c3330277d2e4fa9213294f966a4a66d",
                     "type": "file",
-                    "dest-filename": "external/tarballs/libcdr-0.1.3.tar.bz2"
+                    "dest-filename": "external/tarballs/libcdr-0.1.4.tar.xz"
                 },
                 {
                     "url": "https://dev-www.libreoffice.org/src/libcmis-0.5.1.tar.gz",
@@ -196,40 +200,34 @@
                     "dest-filename": "external/tarballs/libcmis-0.5.1.tar.gz"
                 },
                 {
-                    "url": "https://dev-www.libreoffice.org/src/libe-book-0.1.2.tar.bz2",
-                    "sha256": "b710a57c633205b933015474d0ac0862253d1c52114d535dd09b20939a0d1850",
+                    "url": "https://dev-www.libreoffice.org/src/libe-book-0.1.3.tar.xz",
+                    "sha256": "7e8d8ff34f27831aca3bc6f9cc532c2f90d2057c778963b884ff3d1e34dfe1f9",
                     "type": "file",
-                    "dest-filename": "external/tarballs/libe-book-0.1.2.tar.bz2"
+                    "dest-filename": "external/tarballs/libe-book-0.1.3.tar.xz"
                 },
                 {
-                    "url": "https://dev-www.libreoffice.org/src/libetonyek-0.1.6.tar.bz2",
-                    "sha256": "032f53e8d7691e48a73ddbe74fa84c906ff6ff32a33e6ee2a935b6fdb6aecb78",
+                    "url": "https://dev-www.libreoffice.org/src/libetonyek-0.1.7.tar.xz",
+                    "sha256": "69dbe10d4426d52f09060d489f8eb90dfa1df592e82eb0698d9dbaf38cc734ac",
                     "type": "file",
-                    "dest-filename": "external/tarballs/libetonyek-0.1.6.tar.bz2"
+                    "dest-filename": "external/tarballs/libetonyek-0.1.7.tar.xz"
                 },
                 {
-                    "url": "https://dev-www.libreoffice.org/src/10d61fbaa6a06348823651b1bd7940fe-libexttextcat-3.4.4.tar.bz2",
-                    "sha256": "9595601c41051356d03d0a7d5dcad334fe1b420d221f6885d143c14bb8d62163",
+                    "url": "https://dev-www.libreoffice.org/src/libexttextcat-3.4.5.tar.xz",
+                    "sha256": "13fdbc9d4c489a4d0519e51933a1aa21fe3fb9eb7da191b87f7a63e82797dac8",
                     "type": "file",
-                    "dest-filename": "external/tarballs/10d61fbaa6a06348823651b1bd7940fe-libexttextcat-3.4.4.tar.bz2"
+                    "dest-filename": "external/tarballs/libexttextcat-3.4.5.tar.xz"
                 },
                 {
-                    "url": "https://dev-www.libreoffice.org/src/libfreehand-0.1.1.tar.bz2",
-                    "sha256": "45dab0e5d632eb51eeb00847972ca03835d6791149e9e714f093a9df2b445877",
+                    "url": "https://dev-www.libreoffice.org/src/libfreehand-0.1.2.tar.xz",
+                    "sha256": "0e422d1564a6dbf22a9af598535425271e583514c0f7ba7d9091676420de34ac",
                     "type": "file",
-                    "dest-filename": "external/tarballs/libfreehand-0.1.1.tar.bz2"
+                    "dest-filename": "external/tarballs/libfreehand-0.1.2.tar.xz"
                 },
                 {
-                    "url": "https://dev-www.libreoffice.org/src/libgltf/libgltf-0.1.0.tar.gz",
-                    "sha256": "119e730fbf002dd0eaafa4930167267d7d910aa17f29979ca9ca8b66625fd2da",
+                    "url": "https://dev-www.libreoffice.org/src/language-subtag-registry-2017-12-14.tar.bz2",
+                    "sha256": "0f87b9428cbc2d96d8e4f54a07e3858b4a428e5fec9396bc3b52fb9f248be362",
                     "type": "file",
-                    "dest-filename": "external/tarballs/libgltf-0.1.0.tar.gz"
-                },
-                {
-                    "url": "https://dev-www.libreoffice.org/src/language-subtag-registry-2017-08-15.tar.bz2",
-                    "sha256": "d6a97fc8da5ae54d867e7f1b65ffb51e816cadd11714e45fc23ee0abf81a51ab",
-                    "type": "file",
-                    "dest-filename": "external/tarballs/language-subtag-registry-2017-08-15.tar.bz2"
+                    "dest-filename": "external/tarballs/language-subtag-registry-2017-12-14.tar.bz2"
                 },
                 {
                     "url": "https://dev-www.libreoffice.org/src/liblangtag-0.6.2.tar.bz2",
@@ -238,16 +236,16 @@
                     "dest-filename": "external/tarballs/liblangtag-0.6.2.tar.bz2"
                 },
                 {
-                    "url": "https://dev-www.libreoffice.org/src/libmspub-0.1.2.tar.bz2",
-                    "sha256": "26d488527ffbb0b41686d4bab756e3e6aaeb99f88adeb169d0c16d2cde96859a",
+                    "url": "https://dev-www.libreoffice.org/src/libmspub-0.1.3.tar.xz",
+                    "sha256": "f0225f0ff03f6bec4847d7c2d8719a36cafc4b97a09e504b610372cc5b981c97",
                     "type": "file",
-                    "dest-filename": "external/tarballs/libmspub-0.1.2.tar.bz2"
+                    "dest-filename": "external/tarballs/libmspub-0.1.3.tar.xz"
                 },
                 {
-                    "url": "https://dev-www.libreoffice.org/src/libmwaw-0.3.11.tar.xz",
-                    "sha256": "4b483a196bbe82bc0f7cb4cdf70ef1cedb91139bd2e037eabaed4a4d6ed2299a",
+                    "url": "https://dev-www.libreoffice.org/src/libmwaw-0.3.13.tar.xz",
+                    "sha256": "db55c728448f9c795cd71a0bb6043f6d4744e3e001b955a018a2c634981d5aea",
                     "type": "file",
-                    "dest-filename": "external/tarballs/libmwaw-0.3.11.tar.xz"
+                    "dest-filename": "external/tarballs/libmwaw-0.3.13.tar.xz"
                 },
                 {
                     "url": "https://dev-www.libreoffice.org/src/libodfgen-0.1.6.tar.bz2",
@@ -256,10 +254,10 @@
                     "dest-filename": "external/tarballs/libodfgen-0.1.6.tar.bz2"
                 },
                 {
-                    "url": "https://dev-www.libreoffice.org/src/libpagemaker-0.0.3.tar.bz2",
-                    "sha256": "3b5de037692f8e156777a75e162f6b110fa24c01749e4a66d7eb83f364e52a33",
+                    "url": "https://dev-www.libreoffice.org/src/libpagemaker-0.0.4.tar.xz",
+                    "sha256": "66adacd705a7d19895e08eac46d1e851332adf2e736c566bef1164e7a442519d",
                     "type": "file",
-                    "dest-filename": "external/tarballs/libpagemaker-0.0.3.tar.bz2"
+                    "dest-filename": "external/tarballs/libpagemaker-0.0.4.tar.xz"
                 },
                 {
                     "url": "https://dev-www.libreoffice.org/src/librevenge-0.0.4.tar.bz2",
@@ -268,10 +266,10 @@
                     "dest-filename": "external/tarballs/librevenge-0.0.4.tar.bz2"
                 },
                 {
-                    "url": "https://dev-www.libreoffice.org/src/libstaroffice-0.0.3.tar.xz",
-                    "sha256": "bedeec104b4cc3896b3dfd1976dda5ce7392d1942bf8f5d2f7d796cc47e422c6",
+                    "url": "https://dev-www.libreoffice.org/src/libstaroffice-0.0.5.tar.xz",
+                    "sha256": "315507add58068aa6d5c437e7c2a6fd1abe684515915152c6cf338fc588da982",
                     "type": "file",
-                    "dest-filename": "external/tarballs/libstaroffice-0.0.3.tar.xz"
+                    "dest-filename": "external/tarballs/libstaroffice-0.0.5.tar.xz"
                 },
                 {
                     "url": "https://dev-www.libreoffice.org/src/ltm-1.0.zip",
@@ -280,34 +278,34 @@
                     "dest-filename": "external/tarballs/ltm-1.0.zip"
                 },
                 {
-                    "url": "https://dev-www.libreoffice.org/src/libvisio-0.1.5.tar.bz2",
-                    "sha256": "b83b7991a40b4e7f07d0cac7bb46ddfac84dece705fd18e21bfd119a09be458e",
+                    "url": "https://dev-www.libreoffice.org/src/libvisio-0.1.6.tar.xz",
+                    "sha256": "fe1002d3671d53c09bc65e47ec948ec7b67e6fb112ed1cd10966e211a8bb50f9",
                     "type": "file",
-                    "dest-filename": "external/tarballs/libvisio-0.1.5.tar.bz2"
+                    "dest-filename": "external/tarballs/libvisio-0.1.6.tar.xz"
                 },
                 {
-                    "url": "https://dev-www.libreoffice.org/src/libwpd-0.10.1.tar.bz2",
-                    "sha256": "efc20361d6e43f9ff74de5f4d86c2ce9c677693f5da08b0a88d603b7475a508d",
+                    "url": "https://dev-www.libreoffice.org/src/libwpd-0.10.2.tar.xz",
+                    "sha256": "323f68beaf4f35e5a4d7daffb4703d0566698280109210fa4eaa90dea27d6610",
                     "type": "file",
-                    "dest-filename": "external/tarballs/libwpd-0.10.1.tar.bz2"
+                    "dest-filename": "external/tarballs/libwpd-0.10.2.tar.xz"
                 },
                 {
-                    "url": "https://dev-www.libreoffice.org/src/libwpg-0.3.1.tar.bz2",
-                    "sha256": "29049b95895914e680390717a243b291448e76e0f82fb4d2479adee5330fbb59",
+                    "url": "https://dev-www.libreoffice.org/src/libwpg-0.3.2.tar.xz",
+                    "sha256": "57faf1ab97d63d57383ac5d7875e992a3d190436732f4083310c0471e72f8c33",
                     "type": "file",
-                    "dest-filename": "external/tarballs/libwpg-0.3.1.tar.bz2"
+                    "dest-filename": "external/tarballs/libwpg-0.3.2.tar.xz"
                 },
                 {
-                    "url": "https://dev-www.libreoffice.org/src/libwps-0.4.6.tar.xz",
-                    "sha256": "e48a7c2fd20048a0a8eaf69bad972575f8b9f06e7497c787463f127d332fccd0",
+                    "url": "https://dev-www.libreoffice.org/src/libwps-0.4.8.tar.xz",
+                    "sha256": "e478e825ef33f6a434a19ff902c5469c9da7acc866ea0d8ab610a8b2aa94177e",
                     "type": "file",
-                    "dest-filename": "external/tarballs/libwps-0.4.6.tar.xz"
+                    "dest-filename": "external/tarballs/libwps-0.4.8.tar.xz"
                 },
                 {
-                    "url": "https://dev-www.libreoffice.org/src/libzmf-0.0.1.tar.bz2",
-                    "sha256": "b69f7f6e94cf695c4b672ca65def4825490a1e7dee34c2126309b96d21a19e6b",
+                    "url": "https://dev-www.libreoffice.org/src/libzmf-0.0.2.tar.xz",
+                    "sha256": "27051a30cb057fdb5d5de65a1f165c7153dc76e27fe62251cbb86639eb2caf22",
                     "type": "file",
-                    "dest-filename": "external/tarballs/libzmf-0.0.1.tar.bz2"
+                    "dest-filename": "external/tarballs/libzmf-0.0.2.tar.xz"
                 },
                 {
                     "url": "https://dev-www.libreoffice.org/src/26b3e95ddf3d9c077c480ea45874b3b8-lp_solve_5.5.tar.gz",
@@ -316,10 +314,10 @@
                     "dest-filename": "external/tarballs/26b3e95ddf3d9c077c480ea45874b3b8-lp_solve_5.5.tar.gz"
                 },
                 {
-                    "url": "https://dev-www.libreoffice.org/src/mdds-1.2.2.tar.bz2",
-                    "sha256": "141e730b39110434b02cd844c5ad3442103f7c35f7e9a4d6a9f8af813594cc9d",
+                    "url": "https://dev-www.libreoffice.org/src/mdds-1.3.1.tar.bz2",
+                    "sha256": "dcb8cd2425567a5a5ec164afea475bce57784bca3e352ad4cbdd3d1a7e08e5a1",
                     "type": "file",
-                    "dest-filename": "external/tarballs/mdds-1.2.2.tar.bz2"
+                    "dest-filename": "external/tarballs/mdds-1.3.1.tar.bz2"
                 },
                 {
                     "url": "https://dev-www.libreoffice.org/src/a8c2c5b8f09e7ede322d5c602ff6a4b6-mythes-1.2.4.tar.gz",
@@ -328,28 +326,34 @@
                     "dest-filename": "external/tarballs/a8c2c5b8f09e7ede322d5c602ff6a4b6-mythes-1.2.4.tar.gz"
                 },
                 {
-                    "url": "https://dev-www.libreoffice.org/src/231adebe5c2f78fded3e3df6e958878e-neon-0.30.1.tar.gz",
-                    "sha256": "00c626c0dc18d094ab374dbd9a354915bfe4776433289386ed489c2ec0845cdd",
+                    "url": "https://dev-www.libreoffice.org/src/neon-0.30.2.tar.gz",
+                    "sha256": "db0bd8cdec329b48f53a6f00199c92d5ba40b0f015b153718d1b15d3d967fbca",
                     "type": "file",
-                    "dest-filename": "external/tarballs/231adebe5c2f78fded3e3df6e958878e-neon-0.30.1.tar.gz"
+                    "dest-filename": "external/tarballs/neon-0.30.2.tar.gz"
                 },
                 {
-                    "url": "https://dev-www.libreoffice.org/src/openldap-2.4.44.tgz",
-                    "sha256": "d7de6bf3c67009c95525dde3a0212cc110d0a70b92af2af8e3ee800e81b88400",
+                    "url": "https://dev-www.libreoffice.org/src/noto-fonts-20171024.tar.gz",
+                    "sha256": "29acc15a4c4d6b51201ba5d60f303dfbc2e5acbfdb70413c9ae1ed34fa259994",
                     "type": "file",
-                    "dest-filename": "external/tarballs/openldap-2.4.44.tgz"
+                    "dest-filename": "external/tarballs/noto-fonts-20171024.tar.gz"
                 },
                 {
-                    "url": "https://dev-www.libreoffice.org/src/liborcus-0.12.1.tar.gz",
-                    "sha256": "676b1fedd721f64489650f5e76d7f98b750439914d87cae505b8163d08447908",
+                    "url": "https://dev-www.libreoffice.org/src/openldap-2.4.45.tgz",
+                    "sha256": "cdd6cffdebcd95161a73305ec13fc7a78e9707b46ca9f84fb897cd5626df3824",
                     "type": "file",
-                    "dest-filename": "external/tarballs/liborcus-0.12.1.tar.gz"
+                    "dest-filename": "external/tarballs/openldap-2.4.45.tgz"
                 },
                 {
-                    "url": "https://dev-www.libreoffice.org/src/poppler-0.56.0.tar.xz",
-                    "sha256": "869dbadf99ed882e776acbdbc06689d8a81872a2963440b1e8516cd7a2577173",
+                    "url": "https://dev-www.libreoffice.org/src/liborcus-0.13.1.tar.gz",
+                    "sha256": "d7041ef455bb78db66b4ba7876af1b3d0fa377b9444e3ef72ceaccd2e8400937",
                     "type": "file",
-                    "dest-filename": "external/tarballs/poppler-0.56.0.tar.xz"
+                    "dest-filename": "external/tarballs/liborcus-0.13.1.tar.gz"
+                },
+                {
+                    "url": "https://dev-www.libreoffice.org/src/poppler-0.59.0.tar.xz",
+                    "sha256": "a3d626b24cd14efa9864e12584b22c9c32f51c46417d7c10ca17651f297c9641",
+                    "type": "file",
+                    "dest-filename": "external/tarballs/poppler-0.59.0.tar.xz"
                 },
                 {
                     "url": "https://dev-www.libreoffice.org/src/c0b4799ea9850eae3ead14f0a60e9418-postgresql-9.2.1.tar.bz2",
@@ -374,13 +378,163 @@
                     "sha256": "de1847f7b59021c16bdc72abb4d8e2d9187cd6124d69156f3326dd34ee043681",
                     "type": "file",
                     "dest-filename": "external/tarballs/e5be03eda13ef68aabab6e42aa67715e-redland-1.0.17.tar.gz"
+                },
+                {
+                    "url": "https://dev-www.libreoffice.org/src/ReemKufi-0.6.tar.gz",
+                    "sha256": "4dfbd8b227ea062ca1742fb15d707f0b74398f9ddb231892554f0959048e809b",
+                    "type": "file",
+                    "dest-filename": "external/tarballs/ReemKufi-0.6.tar.gz"
+                },
+                {
+                    "url": "https://dev-www.libreoffice.org/src/libepubgen-0.1.0.tar.bz2",
+                    "sha256": "730bd1cbeee166334faadbc06c953a67b145c3c4754a3b503482066dae4cd633",
+                    "type": "file",
+                    "dest-filename": "external/tarballs/libepubgen-0.1.0.tar.bz2"
+                },
+                {
+                    "url": "https://dev-www.libreoffice.org/src/libqxp-0.0.1.tar.xz",
+                    "sha256": "8c257f6184ff94aefa7c9fa1cfae82083d55a49247266905c71c53e013f95c73",
+                    "type": "file",
+                    "dest-filename": "external/tarballs/libqxp-0.0.1.tar.xz"
+                },
+                {
+                    "url": "https://dev-www.libreoffice.org/src/alef-1.001.tar.gz",
+                    "sha256": "b98b67602a2c8880a1770f0b9e37c190f29a7e2ade5616784f0b89fbdb75bf52",
+                    "type": "file",
+                    "dest-filename": "external/tarballs/alef-1.001.tar.gz"
+                },
+                {
+                    "url": "https://dev-www.libreoffice.org/src/amiri-0.109.zip",
+                    "sha256": "97ee6e40d87f4b31de15d9a93bb30bf27bf308f0814f4ee9c47365b027402ad6",
+                    "type": "file",
+                    "dest-filename": "external/tarballs/amiri-0.109.zip"
+                },
+                {
+                    "url": "https://dev-www.libreoffice.org/src/culmus-0.131.tar.gz",
+                    "sha256": "dcf112cfcccb76328dcfc095f4d7c7f4d2f7e48d0eed5e78b100d1d77ce2ed1b",
+                    "type": "file",
+                    "dest-filename": "external/tarballs/culmus-0.131.tar.gz"
+                },
+                {
+                    "url": "https://dev-www.libreoffice.org/src/libre-hebrew-1.0.tar.gz",
+                    "sha256": "f596257c1db706ce35795b18d7f66a4db99d427725f20e9384914b534142579a",
+                    "type": "file",
+                    "dest-filename": "external/tarballs/libre-hebrew-1.0.tar.gz"
+                },
+                {
+                    "url": "https://dev-www.libreoffice.org/src/Scheherazade-2.100.zip",
+                    "sha256": "251c8817ceb87d9b661ce1d5b49e732a0116add10abc046be4b8ba5196e149b5",
+                    "type": "file",
+                    "dest-filename": "external/tarballs/Scheherazade-2.100.zip"
+                },
+                {
+                    "url": "https://dev-www.libreoffice.org/src/ttf-kacst_2.01+mry.tar.gz",
+                    "sha256": "dca00f5e655f2f217a766faa73a81f542c5c204aa3a47017c3c2be0b31d00a56",
+                    "type": "file",
+                    "dest-filename": "external/tarballs/ttf-kacst_2.01+mry.tar.gz"
+                },
+                {
+                    "url": "https://dev-www.libreoffice.org/src/beeca87be45ec87d241ddd0e1bad80c1-bsh-2.0b6-src.zip",
+                    "sha256": "9e93c73e23aff644b17dfff656444474c14150e7f3b38b19635e622235e01c96",
+                    "type": "file",
+                    "dest-filename": "external/tarballs/beeca87be45ec87d241ddd0e1bad80c1-bsh-2.0b6-src.zip"
+                },
+                {
+                    "url": "https://dev-www.libreoffice.org/src/commons-logging-1.2-src.tar.gz",
+                    "sha256": "49665da5a60d033e6dff40fe0a7f9173e886ae859ce6096c1afe34c48b677c81",
+                    "type": "file",
+                    "dest-filename": "external/tarballs/commons-logging-1.2-src.tar.gz"
+                },
+                {
+                    "url": "https://dev-www.libreoffice.org/src/ba2930200c9f019c2d93a8c88c651a0f-flow-engine-0.9.4.zip",
+                    "sha256": "233f66e8d25c5dd971716d4200203a612a407649686ef3b52075d04b4c9df0dd",
+                    "type": "file",
+                    "dest-filename": "external/tarballs/ba2930200c9f019c2d93a8c88c651a0f-flow-engine-0.9.4.zip"
+                },
+                {
+                    "url": "https://dev-www.libreoffice.org/src/d8bd5eed178db6e2b18eeed243f85aa8-flute-1.1.6.zip",
+                    "sha256": "1b5b24f7bc543c0362b667692f78db8bab4ed6dafc6172f104d0bd3757d8a133",
+                    "type": "file",
+                    "dest-filename": "external/tarballs/d8bd5eed178db6e2b18eeed243f85aa8-flute-1.1.6.zip"
+                },
+                {
+                    "url": "https://dev-www.libreoffice.org/src/17410483b5b5f267aa18b7e00b65e6e0-hsqldb_1_8_0.zip",
+                    "sha256": "d30b13f4ba2e3b6a2d4f020c0dee0a9fb9fc6fbcc2d561f36b78da4bf3802370",
+                    "type": "file",
+                    "dest-filename": "external/tarballs/17410483b5b5f267aa18b7e00b65e6e0-hsqldb_1_8_0.zip"
+                },
+                {
+                    "url": "https://dev-www.libreoffice.org/src/eeb2c7ddf0d302fba4bfc6e97eac9624-libbase-1.1.6.zip",
+                    "sha256": "75c80359c9ce343c20aab8a36a45cb3b9ee7c61cf92c13ae45399d854423a9ba",
+                    "type": "file",
+                    "dest-filename": "external/tarballs/eeb2c7ddf0d302fba4bfc6e97eac9624-libbase-1.1.6.zip"
+                },
+                {
+                    "url": "https://dev-www.libreoffice.org/src/3bdf40c0d199af31923e900d082ca2dd-libfonts-1.1.6.zip",
+                    "sha256": "e0531091787c0f16c83965fdcbc49162c059d7f0c64669e7f119699321549743",
+                    "type": "file",
+                    "dest-filename": "external/tarballs/3bdf40c0d199af31923e900d082ca2dd-libfonts-1.1.6.zip"
+                },
+                {
+                    "url": "https://dev-www.libreoffice.org/src/3404ab6b1792ae5f16bbd603bd1e1d03-libformula-1.1.7.zip",
+                    "sha256": "5826d1551bf599b85742545f6e01a0079b93c1b2c8434bf409eddb3a29e4726b",
+                    "type": "file",
+                    "dest-filename": "external/tarballs/3404ab6b1792ae5f16bbd603bd1e1d03-libformula-1.1.7.zip"
+                },
+                {
+                    "url": "https://dev-www.libreoffice.org/src/db60e4fde8dd6d6807523deb71ee34dc-liblayout-0.2.10.zip",
+                    "sha256": "e1fb87f3f7b980d33414473279615c4644027e013012d156efa538bc2b031772",
+                    "type": "file",
+                    "dest-filename": "external/tarballs/db60e4fde8dd6d6807523deb71ee34dc-liblayout-0.2.10.zip"
+                },
+                {
+                    "url": "https://dev-www.libreoffice.org/src/97b2d4dba862397f446b217e2b623e71-libloader-1.1.6.zip",
+                    "sha256": "3d853b19b1d94a6efa69e7af90f7f2b09ecf302913bee3da796c15ecfebcfac8",
+                    "type": "file",
+                    "dest-filename": "external/tarballs/97b2d4dba862397f446b217e2b623e71-libloader-1.1.6.zip"
+                },
+                {
+                    "url": "https://dev-www.libreoffice.org/src/8ce2fcd72becf06c41f7201d15373ed9-librepository-1.1.6.zip",
+                    "sha256": "abe2c57ac12ba45d83563b02e240fa95d973376de2f720aab8fe11f2e621c095",
+                    "type": "file",
+                    "dest-filename": "external/tarballs/8ce2fcd72becf06c41f7201d15373ed9-librepository-1.1.6.zip"
+                },
+                {
+                    "url": "https://dev-www.libreoffice.org/src/f94d9870737518e3b597f9265f4e9803-libserializer-1.1.6.zip",
+                    "sha256": "05640a1f6805b2b2d7e2cb9c50db9a5cb084e3c52ab1a71ce015239b4a1d4343",
+                    "type": "file",
+                    "dest-filename": "external/tarballs/f94d9870737518e3b597f9265f4e9803-libserializer-1.1.6.zip"
+                },
+                {
+                    "url": "https://dev-www.libreoffice.org/src/ace6ab49184e329db254e454a010f56d-libxml-1.1.7.zip",
+                    "sha256": "7d2797fe9f79a77009721e3f14fa4a1dec17a6d706bdc93f85f1f01d124fab66",
+                    "type": "file",
+                    "dest-filename": "external/tarballs/ace6ab49184e329db254e454a010f56d-libxml-1.1.7.zip"
+                },
+                {
+                    "url": "https://dev-www.libreoffice.org/src/798b2ffdc8bcfe7bca2cf92b62caf685-rhino1_5R5.zip",
+                    "sha256": "1fb458d6aab06932693cc8a9b6e4e70944ee1ff052fa63606e3131df34e21753",
+                    "type": "file",
+                    "dest-filename": "external/tarballs/798b2ffdc8bcfe7bca2cf92b62caf685-rhino1_5R5.zip"
+                },
+                {
+                    "url": "https://dev-www.libreoffice.org/src/39bb3fcea1514f1369fcfc87542390fd-sacjava-1.3.zip",
+                    "sha256": "085f2112c51fa8c1783fac12fbd452650596415121348393bb51f0f7e85a9045",
+                    "type": "file",
+                    "dest-filename": "external/tarballs/39bb3fcea1514f1369fcfc87542390fd-sacjava-1.3.zip"
+                },
+                {
+                    "url": "https://dev-www.libreoffice.org/src/35c94d2df8893241173de1d16b6034c0-swingExSrc.zip",
+                    "sha256": "64585ac36a81291a58269ec5347e7e3e2e8596dbacb9221015c208191333c6e1",
+                    "type": "file",
+                    "dest-filename": "external/tarballs/35c94d2df8893241173de1d16b6034c0-swingExSrc.zip"
                 }
             ],
             "buildsystem": "simple",
             "build-commands": [
                 "./autogen.sh --prefix=/run/build/libreoffice/inst --with-distro=LibreOfficeFlatpak",
                 "make",
-                "make distro-pack-install-strip",
+                "make distro-pack-install",
                 "make cmd cmd='$(SRCDIR)/solenv/bin/assemble-flatpak.sh'"
             ]
         }
@@ -394,6 +548,7 @@
         "--filesystem=host",
         "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
         "--env=LIBO_FLATPAK=1",
+        "--env=PATH=/usr/bin:/app/jre/bin",
         "--own-name=org.libreoffice.LibreOfficeIpc0",
         "--talk-name=ca.desrt.dconf",
         "--talk-name=org.gtk.vfs.*"


### PR DESCRIPTION
* Add JVM support to Flatpak
* Let flatpak-builder build .Debug extension
* Adapt to changes to external packages and extra fonts