### PR TITLE
Enable device=dri to fix opengl crashes

### DIFF
--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -550,6 +550,7 @@
         "--socket=x11",
         "--socket=wayland",
         "--socket=pulseaudio",
+        "--device=dri",
         "--filesystem=host",
         "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
         "--env=LIBO_FLATPAK=1",


### PR DESCRIPTION
Enabling this fixes LibreOffice crashing if the user selects an opengl enhanced transition in Impress.