### PR TITLE
build on arm again

### DIFF
--- a/flathub.json
+++ b/flathub.json
@@ -1,3 +1,0 @@
-{
-    "skip-arches": ["arm"]
-}


### PR DESCRIPTION
The OpenJDK 9 SDK extension is available on ARM now, and this allows
the LibreOffice Flatpak to build on ARM once more.
https://github.com/flathub/org.freedesktop.Sdk.Extension.openjdk9/pull/5