### PR TITLE
port to freedesktop.org 1.6 runtime

### DIFF
--- a/assemble-flatpak-mkdir-p.patch
+++ b/assemble-flatpak-mkdir-p.patch
@@ -1,0 +1,30 @@
+--- libreoffice-6/solenv/bin/assemble-flatpak.sh~	2018-04-03 10:06:25.027779098 +0000
++++ libreoffice-6/solenv/bin/assemble-flatpak.sh	2018-04-03 10:07:13.960068386 +0000
+@@ -16,8 +16,7 @@
+ cp -r "${PREFIXDIR?}"/lib/libreoffice /app/
+ 
+ ## libreoffice-*.desktop -> org.libreoffice.LibreOffice-*.desktop:
+-mkdir /app/share
+-mkdir /app/share/applications
++mkdir -p /app/share/applications
+ for i in "${PREFIXDIR?}"/share/applications/libreoffice-*.desktop
+ do
+  sed -e 's,^Exec=libreoffice,Exec=/app/libreoffice/program/soffice,' \
+@@ -29,7 +28,7 @@
+ 
+ ## icons/hicolor/*/apps/libreoffice-* ->
+ ## icons/hicolor/*/apps/org.libreoffice.LibreOffice-*:
+-mkdir /app/share/icons
++mkdir -p /app/share/icons
+ for i in "${PREFIXDIR?}"/share/icons/hicolor/*/apps/libreoffice-*
+ do
+  mkdir -p \
+@@ -42,7 +41,7 @@
+ ## inst/share/appdata/libreoffice-*.appdata.xml (at least recent GNOME Software
+ ## doesn't show more than five screenshots anyway, so restrict to one each from
+ ## the five libreoffice-*.appdata.xml: Writer, Calc, Impress, Draw, Base):
+-mkdir /app/share/appdata
++mkdir -p /app/share/appdata
+ cat <<EOF >/app/share/appdata/org.libreoffice.LibreOffice.appdata.xml
+ <?xml version="1.0" encoding="UTF-8"?>
+ <component type="desktop">

--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -69,6 +69,10 @@
                     "disable-fsckobjects": true
                 },
                 {
+                    "type": "patch",
+                    "path": "assemble-flatpak-mkdir-p.patch"
+                },
+                {
                     "type": "archive",
                     "url": "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.2-bin.tar.xz",
                     "sha256": "361c8ad2ed8341416e323e7c28af10a8297170a80fdffba294a5c2031527bb6c",

--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -8,10 +8,10 @@
         "org.freedesktop.Sdk.Extension.openjdk9"
     ],
     "build-options": {
+        "append-ld-library-path": "/usr/lib/sdk/gcc7/lib",
         "env": {
             "CC": "/usr/lib/sdk/gcc7/bin/gcc",
-            "CXX": "/usr/lib/sdk/gcc7/bin/g++",
-            "LD_LIBRARY_PATH": "/usr/lib/sdk/gcc7/lib"
+            "CXX": "/usr/lib/sdk/gcc7/bin/g++"
         }
     },
     "command": "/app/libreoffice/program/soffice",

--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -60,6 +60,16 @@
             ]
         },
         {
+            "name": "gsettings-desktop-schemas",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://download.gnome.org/sources/gsettings-desktop-schemas/3.28/gsettings-desktop-schemas-3.28.0.tar.xz",
+                    "sha256": "4cb4cd7790b77e5542ec75275237613ad22f3a1f2f41903a298cf6cc996a9167"
+                }
+            ]
+        },
+        {
             "name": "libreoffice",
             "sources": [
                 {

--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -1,8 +1,8 @@
 {
     "id": "org.libreoffice.LibreOffice",
-    "runtime": "org.gnome.Platform",
-    "runtime-version": "3.26",
-    "sdk": "org.gnome.Sdk",
+    "runtime": "org.freedesktop.Platform",
+    "runtime-version": "1.6",
+    "sdk": "org.freedesktop.Sdk",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.gcc7",
         "org.freedesktop.Sdk.Extension.openjdk9"
@@ -34,14 +34,28 @@
         },
         {
             "name": "gst-libav",
-            "buildsystem": "meson",
-            "builddir": true,
-            "config-opts": ["-Ddisable_gtkdoc=true"],
+            "config-opts": [ "--disable-gtk-doc", "--with-system-libav" ],
+            "cleanup": [ "*.la", "/share/gtk-doc" ],
+            "sources": [
+                {
+                    "type" : "archive",
+                    "url" : "https://gstreamer.freedesktop.org/src/gst-libav/gst-libav-1.10.5.tar.xz",
+                    "sha256" : "e4d2f315f478d47281fbfdfbd590a63d23704ca37911d7142d5992616f4b28d3"
+                }
+            ]
+        },
+        {
+            "name": "dbus-glib",
+            "cleanup": [ "*.la", "/bin", "/etc", "/include", "/libexec", "/share/gtk-doc", "/share/man" ],
+            "config-opts": [
+                "--disable-static",
+                "--disable-gtk-doc"
+            ],
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://gstreamer.freedesktop.org/src/gst-libav/gst-libav-1.12.4.tar.xz",
-                    "sha256": "2a56aa5d2d8cd912f2bce17f174713d2c417ca298f1f9c28ee66d4aa1e1d9e62"
+                    "url": "https://dbus.freedesktop.org/releases/dbus-glib/dbus-glib-0.108.tar.gz",
+                    "sha256": "9f340c7e2352e9cdf113893ca77ca9075d9f8d5e81476bf2bf361099383c602c"
                 }
             ]
         },
@@ -561,7 +575,7 @@
             ],
             "buildsystem": "simple",
             "build-commands": [
-                "./autogen.sh --prefix=/run/build/libreoffice/inst --with-distro=LibreOfficeFlatpak --disable-symbols $(if test \"$(uname -m)\" = aarch64; then printf %s --disable-pdfium; fi)",
+                "./autogen.sh --prefix=/run/build/libreoffice/inst --with-distro=LibreOfficeFlatpak --disable-symbols --disable-gtk $(if test \"$(uname -m)\" = aarch64; then printf %s --disable-pdfium; fi)",
                 "make $(if test \"$(uname -i)\" = i386; then printf build-nocheck; fi)",
                 "make distro-pack-install",
                 "make cmd cmd='$(SRCDIR)/solenv/bin/assemble-flatpak.sh'"


### PR DESCRIPTION
Gtk+3/GIO/etc dependencies used by LO in "GNOME" mode are actually included in the freedesktop.org runtime, so we can reduce the disk space requirements by targeting this smaller runtime. Try to build against fd.o by downgrading gst-libav (fd.o has gst 1.10 rather than gnome's 1.12), bundling dbus-glib and disable Gtk+ 2. Tweak small bugs in flatpak packaging exposed by bundling dbus-glib.