### PR TITLE
split resource/registry data into Locales extension

### DIFF
--- a/a4999bc4-ignore-dangling-symlink.patch
+++ b/a4999bc4-ignore-dangling-symlink.patch
@@ -1,0 +1,40 @@
+From a4999bc40d6e856ec9230bc1229a8ba0121fb625 Mon Sep 17 00:00:00 2001
+From: Stephan Bergmann <sbergman@redhat.com>
+Date: Wed, 04 Apr 2018 15:44:40 +0200
+Subject: [PATCH] Ignore dangling symlink configuration files
+
+This will be used by the Flatpak build, to offload per-locale data to a Locale
+extension (which expects all per-locale files to be in one place, so we need to
+add---potentially dangling, if a given locale is not installed---symlinks from
+the original places to the location where that Locale extension stores the
+actual files).
+
+Change-Id: Id13b8c53fbc9e0763e53fd09c0c059c9e638c13d
+---
+
+diff --git a/configmgr/source/components.cxx b/configmgr/source/components.cxx
+index 3f99191..e296f8d 100644
+--- a/configmgr/source/components.cxx
++++ b/configmgr/source/components.cxx
+@@ -708,6 +708,10 @@
+                     parseFileLeniently(
+                         parseFile, stat.getFileURL(), layer, nullptr, nullptr, nullptr);
+                 } catch (css::container::NoSuchElementException & e) {
++                    if (stat.getFileType() == osl::FileStatus::Link) {
++                        SAL_WARN("configmgr", "dangling link <" << stat.getFileURL() << ">");
++                        continue;
++                    }
+                     throw css::uno::RuntimeException(
+                         "stat'ed file does not exist: " + e.Message);
+                 }
+@@ -784,6 +788,10 @@
+                         stat.getFileURL(),
+                         new XcdParser(layer, processedDeps, data_));
+                 } catch (css::container::NoSuchElementException & e) {
++                    if (stat.getFileType() == osl::FileStatus::Link) {
++                        SAL_WARN("configmgr", "dangling link <" << stat.getFileURL() << ">");
++                        continue;
++                    }
+                     throw css::uno::RuntimeException(
+                         "stat'ed file does not exist: " + e.Message);
+                 }

--- a/assemble-flatpak-split-locales.patch
+++ b/assemble-flatpak-split-locales.patch
@@ -13,7 +13,7 @@
 +  ln -s ../../../share/runtime/locale/"${lang}"/resource/"${i}" /app/libreoffice/program/resource
 +done
 +
-+for i in /app/libreoffice/share/registry/Langpack-*.xcd /app/libreoffice/share/registry/res/*.xcd
++for i in /app/libreoffice/share/registry/Langpack-*.xcd /app/libreoffice/share/registry/res/{fcfg_langpack,registry}_*.xcd
 +do
 +  basename="$(basename "${i}" .xcd)"
 +  lang="${basename#Langpack-}"

--- a/assemble-flatpak-split-locales.patch
+++ b/assemble-flatpak-split-locales.patch
@@ -1,0 +1,37 @@
+--- libreoffice-6/solenv/bin/assemble-flatpak.sh~	2018-04-03 15:23:51.803596867 +0000
++++ libreoffice-6/solenv/bin/assemble-flatpak.sh	2018-04-04 14:03:30.887072971 +0000
+@@ -37,6 +37,34 @@
+   "$(dirname /app/share/icons/hicolor/"${i#"${PREFIXDIR?}"/share/icons/hicolor/}")"/org.libreoffice.LibreOffice-"${i##*/apps/libreoffice-}"
+ done
+ 
++mkdir -p /app/share/runtime/locale
++for i in $(ls /app/libreoffice/program/resource)
++do
++  lang="${i%[_@]*}"
++  mkdir -p /app/share/runtime/locale/"${lang}"/resource
++  mv /app/libreoffice/program/resource/"${i}" /app/share/runtime/locale/"${lang}"/resource
++  ln -s ../../../share/runtime/locale/"${lang}"/resource/"${i}" /app/libreoffice/program/resource
++done
++
++for i in /app/libreoffice/share/registry/Langpack-*.xcd /app/libreoffice/share/registry/res/*.xcd
++do
++  basename="$(basename "${i}" .xcd)"
++  lang="${basename#Langpack-}"
++  lang="${lang#fcfg_langpack_}"
++  lang="${lang#registry_}"
++
++  # ship the base app with at least one Langpack/fcfg_langpack
++  if [ "${lang}" = "en-US" ]
++  then
++    continue
++  fi
++
++  lang="${lang%-*}"
++  mkdir -p /app/share/runtime/locale/"${lang}"/registry
++  mv "${i}" /app/share/runtime/locale/"${lang}"/registry
++  ln -rs /app/share/runtime/locale/"${lang}"/registry/"${basename}".xcd "${i}"
++done
++
+ ## org.libreoffice.LibreOffice.appdata.xml is manually derived from the various
+ ## inst/share/appdata/libreoffice-*.appdata.xml (at least recent GNOME Software
+ ## doesn't show more than five screenshots anyway, so restrict to one each from

--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -15,7 +15,6 @@
         }
     },
     "command": "/app/libreoffice/program/soffice",
-    "separate-locales": false,
     "modules": [
         {
             "name": "gcc7",
@@ -71,6 +70,14 @@
                 {
                     "type": "patch",
                     "path": "assemble-flatpak-mkdir-p.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "assemble-flatpak-split-locales.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "a4999bc4-ignore-dangling-symlink.patch"
                 },
                 {
                     "type": "archive",


### PR DESCRIPTION
Move the language-specific data into the /app/share/runtime path which
flatpak-builder splits into the Locale extension if we re-enable
separate-locales. We symlink the original locations back to these paths, which
means we have dangling symlinks depending on which Locale sutpaths are
installed.

Include Stephan Bergmann's patch from https://gerrit.libreoffice.org/#/c/52381/
to make the configmgr robust to such dangling links.