### PR TITLE
edit .desktop files to add X-Endless-Alias with original names

### DIFF
--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -589,7 +589,9 @@
                 "./autogen.sh --prefix=/run/build/libreoffice/inst --with-distro=LibreOfficeFlatpak --disable-symbols --disable-gtk $(if test \"$(uname -m)\" = aarch64; then printf %s --disable-pdfium; fi)",
                 "make $(if test \"$(uname -i)\" = i386; then printf build-nocheck; fi)",
                 "make distro-pack-install",
-                "make cmd cmd='$(SRCDIR)/solenv/bin/assemble-flatpak.sh'"
+                "make cmd cmd='$(SRCDIR)/solenv/bin/assemble-flatpak.sh'",
+                "desktop-file-edit --set-key=X-Endless-Alias --set-value=libreoffice-startcenter /app/share/applications/org.libreoffice.LibreOffice.desktop",
+                "for i in base calc draw impress math writer xsltfilter; do desktop-file-edit --set-key=X-Endless-Alias --set-value=libreoffice-$i /app/share/applications/org.libreoffice.LibreOffice-$i.desktop; done"
             ]
         }
     ],


### PR DESCRIPTION
Endless OS uses this to update icon grids & taskbar pins if the original files
have been removed. (Happy to update this to a more standardised key if a
consensus emerges.)