### PR TITLE
clean up desktop integration

### DIFF
--- a/assemble-flatpak-desktop-integration.patch
+++ b/assemble-flatpak-desktop-integration.patch
@@ -1,0 +1,36 @@
+--- libreoffice/solenv/bin/assemble-flatpak.sh~	2018-04-26 19:28:40.094251698 +0100
++++ libreoffice/solenv/bin/assemble-flatpak.sh	2018-04-27 12:53:09.732564083 +0100
+@@ -26,6 +26,10 @@
+ mv /app/share/applications/org.libreoffice.LibreOffice-startcenter.desktop \
+  /app/share/applications/org.libreoffice.LibreOffice.desktop
+ 
++# Flatpak .desktop exports take precedence over system ones due to
++# the order of XDG_DATA_DIRS - re-associating text/plain seems a bit much
++sed -i "s/text\/plain;//" /app/share/applications/org.libreoffice.LibreOffice-writer.desktop
++
+ ## icons/hicolor/*/apps/libreoffice-* ->
+ ## icons/hicolor/*/apps/org.libreoffice.LibreOffice-*:
+ mkdir -p /app/share/icons
+@@ -34,6 +38,8 @@
+  mkdir -p \
+   "$(dirname /app/share/icons/hicolor/"${i#"${PREFIXDIR?}"/share/icons/hicolor/}")"
+  cp -a "$i" \
++  "$(dirname /app/share/icons/hicolor/"${i#"${PREFIXDIR?}"/share/icons/hicolor/}")"/"$(basename "$i")"
++ cp -a "$i" \
+   "$(dirname /app/share/icons/hicolor/"${i#"${PREFIXDIR?}"/share/icons/hicolor/}")"/org.libreoffice.LibreOffice-"${i##*/apps/libreoffice-}"
+ done
+ 
+@@ -133,6 +139,13 @@
+ </component>
+ EOF
+ 
++# append the appdata for the different components
++for i in "${PREFIXDIR?}"/share/appdata/libreoffice-*.appdata.xml
++do
++  sed "1 d; s/<id>libreoffice/<id>org.libreoffice.LibreOffice/" "$i" \
++    >>/app/share/appdata/org.libreoffice.LibreOffice.appdata.xml
++done
++
+ ## see <https://github.com/flatpak/flatpak/blob/master/app/
+ ## flatpak-builtins-build-finish.c> for further places where build-finish would
+ ## look for data:

--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -77,6 +77,10 @@
                 },
                 {
                     "type": "patch",
+                    "path": "assemble-flatpak-desktop-integration.patch"
+                },
+                {
+                    "type": "patch",
                     "path": "a4999bc4-ignore-dangling-symlink.patch"
                 },
                 {


### PR DESCRIPTION
 - don't register MIME handler for text/plain (Flatpak appears first in
   XDG_DATA_DIRS so otherwise we "steal" the default text editor association)
 - copy the icons app into the theme with both their original libreoffice-*
   name as well as the org.libreoffice name needed by Flatpak, which fixes the
   window icons
 - append the appdata for the separate apps (Base, Draw, etc) to the appdata
   XML we export for Flatpak, so they are visible in software centers etc