### PR TITLE
add missing share of dconf runtime dir

### DIFF
--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -595,6 +595,7 @@
         "--socket=pulseaudio",
         "--device=dri",
         "--filesystem=host",
+        "--filesystem=xdg-run/dconf",
         "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
         "--env=JAVA_HOME=/app/jre",
         "--env=LIBO_FLATPAK=1",


### PR DESCRIPTION
This breaks dconf change notifications, including the GSettings used for Gtk+
themes. Could also cause other weird settings problems.

https://github.com/flathub/org.libreoffice.LibreOffice/issues/31