### PR TITLE
rename sub-app .desktop files so they are strict sub-IDs

### DIFF
--- a/assemble-flatpak-dotty-appid.patch
+++ b/assemble-flatpak-dotty-appid.patch
@@ -1,0 +1,40 @@
+--- libreoffice-1/solenv/bin/assemble-flatpak.sh~	2018-05-15 11:33:39.466673280 +0000
++++ libreoffice-1/solenv/bin/assemble-flatpak.sh	2018-05-15 12:04:51.321521517 +0000
+@@ -20,15 +20,15 @@
+ for i in "${PREFIXDIR?}"/share/applications/libreoffice-*.desktop
+ do
+  sed -e 's,^Exec=libreoffice,Exec=/app/libreoffice/program/soffice,' \
+-  -e 's/^Icon=libreoffice-/Icon=org.libreoffice.LibreOffice-/' "$i" \
+-  >/app/share/applications/org.libreoffice.LibreOffice-"${i#"${PREFIXDIR?}"/share/applications/libreoffice-}"
++  -e 's/^Icon=libreoffice-/Icon=org.libreoffice.LibreOffice./' "$i" \
++  >/app/share/applications/org.libreoffice.LibreOffice."${i#"${PREFIXDIR?}"/share/applications/libreoffice-}"
+ done
+-mv /app/share/applications/org.libreoffice.LibreOffice-startcenter.desktop \
++mv /app/share/applications/org.libreoffice.LibreOffice.startcenter.desktop \
+  /app/share/applications/org.libreoffice.LibreOffice.desktop
+ 
+ # Flatpak .desktop exports take precedence over system ones due to
+ # the order of XDG_DATA_DIRS - re-associating text/plain seems a bit much
+-sed -i "s/text\/plain;//" /app/share/applications/org.libreoffice.LibreOffice-writer.desktop
++sed -i "s/text\/plain;//" /app/share/applications/org.libreoffice.LibreOffice.writer.desktop
+ 
+ ## icons/hicolor/*/apps/libreoffice-* ->
+ ## icons/hicolor/*/apps/org.libreoffice.LibreOffice-*:
+@@ -40,7 +40,7 @@
+  cp -a "$i" \
+   "$(dirname /app/share/icons/hicolor/"${i#"${PREFIXDIR?}"/share/icons/hicolor/}")"/"$(basename "$i")"
+  cp -a "$i" \
+-  "$(dirname /app/share/icons/hicolor/"${i#"${PREFIXDIR?}"/share/icons/hicolor/}")"/org.libreoffice.LibreOffice-"${i##*/apps/libreoffice-}"
++  "$(dirname /app/share/icons/hicolor/"${i#"${PREFIXDIR?}"/share/icons/hicolor/}")"/org.libreoffice.LibreOffice."${i##*/apps/libreoffice-}"
+ done
+ 
+ mkdir -p /app/share/runtime/locale
+@@ -142,7 +142,7 @@
+ # append the appdata for the different components
+ for i in "${PREFIXDIR?}"/share/appdata/libreoffice-*.appdata.xml
+ do
+-  sed "1 d; s/<id>libreoffice/<id>org.libreoffice.LibreOffice/" "$i" \
++  sed "1 d; s/<id>libreoffice-/<id>org.libreoffice.LibreOffice./" "$i" \
+     >>/app/share/appdata/org.libreoffice.LibreOffice.appdata.xml
+ done
+ 

--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -46,6 +46,10 @@
                     "path": "0001-The-gcc3_linux_aarch64-bridge-needs-to-call-__cxa_cu.patch"
                 },
                 {
+                    "type": "patch",
+                    "path": "assemble-flatpak-dotty-appid.patch"
+                },
+                {
                     "type": "archive",
                     "url": "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.2-bin.tar.xz",
                     "sha256": "361c8ad2ed8341416e323e7c28af10a8297170a80fdffba294a5c2031527bb6c",
@@ -568,8 +572,8 @@
                 "make $(if test \"$FLATPAK_ARCH\" = i386; then printf build-nocheck; fi)",
                 "make distro-pack-install",
                 "make cmd cmd='$(SRCDIR)/solenv/bin/assemble-flatpak.sh'",
-                "desktop-file-edit --set-key=X-Endless-Alias --set-value=libreoffice-startcenter /app/share/applications/org.libreoffice.LibreOffice.desktop",
-                "for i in base calc draw impress math writer xsltfilter; do desktop-file-edit --set-key=X-Endless-Alias --set-value=libreoffice-$i /app/share/applications/org.libreoffice.LibreOffice-$i.desktop; done"
+                "desktop-file-edit --set-key=X-Endless-Alias --set-value=libreoffice-startcenter --set-key=X-Flatpak-RenamedFrom --set-value='libreoffice-startcenter.desktop;' /app/share/applications/org.libreoffice.LibreOffice.desktop",
+                "for i in base calc draw impress math writer xsltfilter; do desktop-file-edit --set-key=X-Endless-Alias --set-value=libreoffice-$i --set-key=X-Flatpak-RenamedFrom --set-value='libreoffice-$i.desktop;org.libreoffice.LibreOffice-$i.desktop;' /app/share/applications/org.libreoffice.LibreOffice.$i.desktop; done"
             ]
         }
     ],


### PR DESCRIPTION
The org.libreoffice.LibreOffice-foo names are not actually sub-IDs of
org.libreoffice.LibreOffice which means that Flatpak will not export the
additional components in the appstream. Change the - to . so that the
sub-apps are correctly within the org.libreoffice.LibreOffice namespace
rather than a mere prefix match. Set the X-Flatpak-RenamedFrom list
in the .desktop files to include both the original upstream names
and the - delimited old IDs that we used previous in the Flatpak.

https://github.com/flathub/org.libreoffice.LibreOffice/issues/36