### PR TITLE
Support "Preview in Web Browser" in Flatpak mode

### DIFF
--- a/0001-Support-Preview-in-Web-Browser-in-Flatpak-mode.patch
+++ b/0001-Support-Preview-in-Web-Browser-in-Flatpak-mode.patch
@@ -1,0 +1,403 @@
+From c61e7b9940cb30800d6f1000727f9cfd5de9fa5e Mon Sep 17 00:00:00 2001
+From: Stephan Bergmann <sbergman@redhat.com>
+Date: Tue, 30 Apr 2019 10:38:38 +0200
+Subject: [PATCH] Support "Preview in Web Browser" in Flatpak mode
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+...by storing the temporary HTML document in a location that can be accessed by
+the browser running outside the Flatpak sandbox.  This reuses and extends the
+mechanism already in place for the new HTML-based help in Flatpak mode (see
+72b936d70b7eaa6d9f5f911b27e3c955382de967 "Enable --help=html for flatpak").
+
+This fixes <https://github.com/flathub/org.libreoffice.LibreOffice/issues/85>
+"“Preview in Web Browser” does not work in Flatpak version".
+
+Change-Id: I5f73fd89139ffe6b8ab0dc501154b4f054a0ae5c
+Reviewed-on: https://gerrit.libreoffice.org/71570
+Tested-by: Jenkins
+Reviewed-by: Stephan Bergmann <sbergman@redhat.com>
+---
+ desktop/source/app/app.cxx    |  4 +-
+ include/sfx2/flatpak.hxx      | 34 ++++++++++++
+ include/sfx2/sfxhelp.hxx      |  2 -
+ sfx2/Library_sfx.mk           |  1 +
+ sfx2/source/appl/flatpak.cxx  | 99 +++++++++++++++++++++++++++++++++++
+ sfx2/source/appl/sfxhelp.cxx  | 74 ++------------------------
+ sfx2/source/view/viewsh.cxx   | 12 ++++-
+ solenv/clang-format/blacklist |  2 +
+ 8 files changed, 151 insertions(+), 77 deletions(-)
+ create mode 100644 include/sfx2/flatpak.hxx
+ create mode 100644 sfx2/source/appl/flatpak.cxx
+
+diff --git a/desktop/source/app/app.cxx b/desktop/source/app/app.cxx
+index e584858b3191..c516d19a6862 100644
+--- a/desktop/source/app/app.cxx
++++ b/desktop/source/app/app.cxx
+@@ -110,7 +110,7 @@
+ #include <vcl/help.hxx>
+ #include <vcl/weld.hxx>
+ #include <vcl/settings.hxx>
+-#include <sfx2/sfxhelp.hxx>
++#include <sfx2/flatpak.hxx>
+ #include <sfx2/sfxsids.hrc>
+ #include <sfx2/app.hxx>
+ #include <sfx2/safemode.hxx>
+@@ -1696,7 +1696,7 @@ int Desktop::doShutdown()
+ 
+     // remove temp directory
+     RemoveTemporaryDirectory();
+-    SfxHelp::removeFlatpakHelpTemporaryDirectory();
++    flatpak::removeTemporaryHtmlDirectory();
+ 
+     // flush evtl. configuration changes so that all config files in user
+     // dir are written
+diff --git a/include/sfx2/flatpak.hxx b/include/sfx2/flatpak.hxx
+new file mode 100644
+index 000000000000..cb5d758b51fe
+--- /dev/null
++++ b/include/sfx2/flatpak.hxx
+@@ -0,0 +1,34 @@
++/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
++/*
++ * This file is part of the LibreOffice project.
++ *
++ * This Source Code Form is subject to the terms of the Mozilla Public
++ * License, v. 2.0. If a copy of the MPL was not distributed with this
++ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
++ */
++
++#ifndef INCLUDED_INCLUDE_SFX2_FLATPAK_HXX
++#define INCLUDED_INCLUDE_SFX2_FLATPAK_HXX
++
++#include <sal/config.h>
++
++#include <rtl/ustring.hxx>
++#include <sfx2/dllapi.h>
++
++// Functionality related to the Flatpak version of LibreOffice.
++
++namespace flatpak {
++
++bool isFlatpak();
++
++// Must only be called with SolarMutex locked:
++bool createTemporaryHtmlDirectory(OUString ** url);
++
++// Must only be called with SolarMutex locked:
++SFX2_DLLPUBLIC void removeTemporaryHtmlDirectory();
++
++}
++
++#endif
++
++/* vim:set shiftwidth=4 softtabstop=4 expandtab cinoptions=b1,g0,N-s cinkeys+=0=break: */
+diff --git a/include/sfx2/sfxhelp.hxx b/include/sfx2/sfxhelp.hxx
+index 5dd0a81fc1e9..e76872f3f201 100644
+--- a/include/sfx2/sfxhelp.hxx
++++ b/include/sfx2/sfxhelp.hxx
+@@ -50,8 +50,6 @@ public:
+     static OUString         GetCurrentModuleIdentifier();
+     // Check for built-in help
+     static bool             IsHelpInstalled();
+-
+-    static void removeFlatpakHelpTemporaryDirectory();
+ };
+ 
+ #endif // INCLUDED_SFX2_SFXHELP_HXX
+diff --git a/sfx2/Library_sfx.mk b/sfx2/Library_sfx.mk
+index 6b10dfa021ee..d4fb4cf6b972 100644
+--- a/sfx2/Library_sfx.mk
++++ b/sfx2/Library_sfx.mk
+@@ -94,6 +94,7 @@ $(eval $(call gb_Library_add_exception_objects,sfx,\
+     sfx2/source/appl/childwin \
+     sfx2/source/appl/childwinimpl \
+     sfx2/source/appl/fileobj \
++    sfx2/source/appl/flatpak \
+     sfx2/source/appl/fwkhelper \
+     sfx2/source/appl/helpdispatch \
+     sfx2/source/appl/helpinterceptor \
+diff --git a/sfx2/source/appl/flatpak.cxx b/sfx2/source/appl/flatpak.cxx
+new file mode 100644
+index 000000000000..14411dafc5d0
+--- /dev/null
++++ b/sfx2/source/appl/flatpak.cxx
+@@ -0,0 +1,99 @@
++/* -*- Mode: C++; tab-width: 4; indent-tabs-mode: nil; c-basic-offset: 4; fill-column: 100 -*- */
++/*
++ * This file is part of the LibreOffice project.
++ *
++ * This Source Code Form is subject to the terms of the Mozilla Public
++ * License, v. 2.0. If a copy of the MPL was not distributed with this
++ * file, You can obtain one at http://mozilla.org/MPL/2.0/.
++ */
++
++#include <sal/config.h>
++
++#include <cassert>
++#include <cstdlib>
++#include <cstring>
++
++#include <osl/file.hxx>
++#include <osl/thread.h>
++#include <rtl/textcvt.h>
++#include <rtl/ustring.h>
++#include <rtl/ustring.hxx>
++#include <sal/log.hxx>
++#include <sfx2/flatpak.hxx>
++#include <tools/debug.hxx>
++#include <unotools/tempfile.hxx>
++#include <unotools/ucbhelper.hxx>
++
++bool flatpak::isFlatpak() {
++    static auto const flatpak = [] { return std::getenv("LIBO_FLATPAK") != nullptr; }();
++    return flatpak;
++}
++
++namespace {
++
++// Must only be accessed with SolarMutex locked:
++struct {
++    bool created = false;
++    OUString url;
++} temporaryHtmlDirectoryStatus;
++
++}
++
++bool flatpak::createTemporaryHtmlDirectory(OUString ** url) {
++    assert(url != nullptr);
++    DBG_TESTSOLARMUTEX();
++    if (!temporaryHtmlDirectoryStatus.created) {
++        auto const env = std::getenv("XDG_CACHE_HOME");
++        if (env == nullptr) {
++            SAL_WARN("sfx.appl", "LIBO_FLATPAK mode but unset XDG_CACHE_HOME");
++            return false;
++        }
++        OUString path;
++        if (!rtl_convertStringToUString(
++                &path.pData, env, std::strlen(env), osl_getThreadTextEncoding(),
++                (RTL_TEXTTOUNICODE_FLAGS_UNDEFINED_ERROR | RTL_TEXTTOUNICODE_FLAGS_MBUNDEFINED_ERROR
++                 | RTL_TEXTTOUNICODE_FLAGS_INVALID_ERROR)))
++        {
++            SAL_WARN(
++                "sfx.appl",
++                "LIBO_FLATPAK mode failure converting XDG_CACHE_HOME \"" << env << "\" encoding");
++            return false;
++        }
++        OUString parent;
++        auto const err = osl::FileBase::getFileURLFromSystemPath(path, parent);
++        if (err != osl::FileBase::E_None) {
++            SAL_WARN(
++                "sfx.appl",
++                "LIBO_FLATPAK mode failure converting XDG_CACHE_HOME \"" << path << "\" to URL: "
++                    << err);
++            return false;
++        }
++        if (!parent.endsWith("/")) {
++            parent += "/";
++        }
++        auto const tmp = utl::TempFile(&parent, true);
++        if (!tmp.IsValid()) {
++            SAL_WARN(
++                "sfx.appl", "LIBO_FLATPAK mode failure creating temp dir at <" << parent << ">");
++            return false;
++        }
++        temporaryHtmlDirectoryStatus.url = tmp.GetURL();
++        temporaryHtmlDirectoryStatus.created = true;
++    }
++    *url = &temporaryHtmlDirectoryStatus.url;
++    return true;
++}
++
++void flatpak::removeTemporaryHtmlDirectory() {
++    DBG_TESTSOLARMUTEX();
++    if (temporaryHtmlDirectoryStatus.created) {
++        if (!utl::UCBContentHelper::Kill(temporaryHtmlDirectoryStatus.url)) {
++            SAL_INFO(
++                "sfx.appl",
++                "LIBO_FLATPAK mode failure removing directory <"
++                    << temporaryHtmlDirectoryStatus.url << ">");
++        }
++    }
++}
++
++/* vim:set shiftwidth=4 softtabstop=4 expandtab cinoptions=b1,g0,N-s cinkeys+=0=break: */
+diff --git a/sfx2/source/appl/sfxhelp.cxx b/sfx2/source/appl/sfxhelp.cxx
+index d2593d468129..daeaeddb2b40 100644
+--- a/sfx2/source/appl/sfxhelp.cxx
++++ b/sfx2/source/appl/sfxhelp.cxx
+@@ -58,7 +58,6 @@
+ #include <osl/file.hxx>
+ #include <unotools/bootstrap.hxx>
+ #include <unotools/tempfile.hxx>
+-#include <unotools/ucbhelper.hxx>
+ #include <rtl/uri.hxx>
+ #include <vcl/commandinfoprovider.hxx>
+ #include <vcl/layout.hxx>
+@@ -75,6 +74,7 @@
+ #include "newhelp.hxx"
+ #include <sfx2/objsh.hxx>
+ #include <sfx2/docfac.hxx>
++#include <sfx2/flatpak.hxx>
+ #include <sfx2/sfxresid.hxx>
+ #include <helper.hxx>
+ #include <sfx2/strings.hrc>
+@@ -724,11 +724,6 @@ static bool impl_showOnlineHelp( const OUString& rURL )
+ 
+ namespace {
+ 
+-bool isFlatpak() {
+-    static auto const flatpak = [] { return std::getenv("LIBO_FLATPAK") != nullptr; }();
+-    return flatpak;
+-}
+-
+ bool rewriteFlatpakHelpRootUrl(OUString * helpRootUrl) {
+     assert(helpRootUrl != nullptr);
+     //TODO: this function for now assumes that the passed-in *helpRootUrl references
+@@ -894,57 +889,6 @@ bool rewriteFlatpakHelpRootUrl(OUString * helpRootUrl) {
+     }
+ }
+ 
+-// Must only be accessed with SolarMutex locked:
+-static struct {
+-    bool created = false;
+-    OUString url;
+-} flatpakHelpTemporaryDirectoryStatus;
+-
+-bool createFlatpakHelpTemporaryDirectory(OUString ** url) {
+-    assert(url != nullptr);
+-    DBG_TESTSOLARMUTEX();
+-    if (!flatpakHelpTemporaryDirectoryStatus.created) {
+-        auto const env = std::getenv("XDG_CACHE_HOME");
+-        if (env == nullptr) {
+-            SAL_WARN("sfx.appl", "LIBO_FLATPAK mode but unset XDG_CACHE_HOME");
+-            return false;
+-        }
+-        OUString path;
+-        if (!rtl_convertStringToUString(
+-                &path.pData, env, std::strlen(env), osl_getThreadTextEncoding(),
+-                (RTL_TEXTTOUNICODE_FLAGS_UNDEFINED_ERROR | RTL_TEXTTOUNICODE_FLAGS_MBUNDEFINED_ERROR
+-                 | RTL_TEXTTOUNICODE_FLAGS_INVALID_ERROR)))
+-        {
+-            SAL_WARN(
+-                "sfx.appl",
+-                "LIBO_FLATPAK mode failure converting XDG_CACHE_HOME \"" << env << "\" encoding");
+-            return false;
+-        }
+-        OUString parent;
+-        auto const err = osl::FileBase::getFileURLFromSystemPath(path, parent);
+-        if (err != osl::FileBase::E_None) {
+-            SAL_WARN(
+-                "sfx.appl",
+-                "LIBO_FLATPAK mode failure converting XDG_CACHE_HOME \"" << path << "\" to URL: "
+-                    << err);
+-            return false;
+-        }
+-        if (!parent.endsWith("/")) {
+-            parent += "/";
+-        }
+-        auto const tmp = utl::TempFile(&parent, true);
+-        if (!tmp.IsValid()) {
+-            SAL_WARN(
+-                "sfx.appl", "LIBO_FLATPAK mode failure creating temp dir at <" << parent << ">");
+-            return false;
+-        }
+-        flatpakHelpTemporaryDirectoryStatus.url = tmp.GetURL();
+-        flatpakHelpTemporaryDirectoryStatus.created = true;
+-    }
+-    *url = &flatpakHelpTemporaryDirectoryStatus.url;
+-    return true;
+-}
+-
+ }
+ 
+ #define SHTML1 "<!DOCTYPE HTML><html lang=\"en-US\"><head><meta charset=\"UTF-8\">"
+@@ -957,7 +901,7 @@ static bool impl_showOfflineHelp( const OUString& rURL )
+     OUString aBaseInstallPath = getHelpRootURL();
+     // For the flatpak case, find the pathname outside the flatpak sandbox that corresponds to
+     // aBaseInstallPath, because that is what needs to be stored in aTempFile below:
+-    if (isFlatpak() && !rewriteFlatpakHelpRootUrl(&aBaseInstallPath)) {
++    if (flatpak::isFlatpak() && !rewriteFlatpakHelpRootUrl(&aBaseInstallPath)) {
+         return false;
+     }
+ 
+@@ -970,7 +914,7 @@ static bool impl_showOfflineHelp( const OUString& rURL )
+     // technical reasons, so that it can be accessed by the browser running outside the sandbox):
+     OUString const aExtension(".html");
+     OUString * parent = nullptr;
+-    if (isFlatpak() && !createFlatpakHelpTemporaryDirectory(&parent)) {
++    if (flatpak::isFlatpak() && !flatpak::createTemporaryHtmlDirectory(&parent)) {
+         return false;
+     }
+     ::utl::TempFile aTempFile("NewHelp", true, &aExtension, parent, false );
+@@ -1366,16 +1310,4 @@ bool SfxHelp::IsHelpInstalled()
+     return impl_hasHelpInstalled();
+ }
+ 
+-void SfxHelp::removeFlatpakHelpTemporaryDirectory() {
+-    DBG_TESTSOLARMUTEX();
+-    if (flatpakHelpTemporaryDirectoryStatus.created) {
+-        if (!utl::UCBContentHelper::Kill(flatpakHelpTemporaryDirectoryStatus.url)) {
+-            SAL_INFO(
+-                "sfx.appl",
+-                "LIBO_FLATPAK mode failure removing directory <"
+-                    << flatpakHelpTemporaryDirectoryStatus.url << ">");
+-        }
+-    }
+-}
+-
+ /* vim:set shiftwidth=4 softtabstop=4 expandtab: */
+diff --git a/sfx2/source/view/viewsh.cxx b/sfx2/source/view/viewsh.cxx
+index 57677b689784..f2d77e2ed3bb 100644
+--- a/sfx2/source/view/viewsh.cxx
++++ b/sfx2/source/view/viewsh.cxx
+@@ -68,6 +68,7 @@
+ 
+ #include <officecfg/Setup.hxx>
+ #include <sfx2/app.hxx>
++#include <sfx2/flatpak.hxx>
+ #include <sfx2/viewsh.hxx>
+ #include "viewimp.hxx"
+ #include <sfx2/sfxresid.hxx>
+@@ -616,8 +617,15 @@ void SfxViewShell::ExecMisc_Impl( SfxRequest &rReq )
+                 OSL_ASSERT( !aFilterName.isEmpty() );
+                 OSL_ASSERT( !aFileName.isEmpty() );
+ 
+-                // Creates a temporary directory to store our predefined file into it.
+-                ::utl::TempFile aTempDir( nullptr, true );
++                // Creates a temporary directory to store our predefined file into it (for the
++                // flatpak case, create it in XDG_CACHE_HOME instead of /tmp for technical reasons,
++                // so that it can be accessed by the browser running outside the sandbox):
++                OUString * parent = nullptr;
++                if (flatpak::isFlatpak() && !flatpak::createTemporaryHtmlDirectory(&parent))
++                {
++                    SAL_WARN("sfx.view", "cannot create Flatpak html temp dir");
++                }
++                ::utl::TempFile aTempDir( parent, true );
+ 
+                 INetURLObject aFilePathObj( aTempDir.GetURL() );
+                 aFilePathObj.insertName( aFileName );
+diff --git a/solenv/clang-format/blacklist b/solenv/clang-format/blacklist
+index a928834cbe55..900fd3eaea92 100644
+--- a/solenv/clang-format/blacklist
++++ b/solenv/clang-format/blacklist
+@@ -6713,6 +6713,7 @@ include/sfx2/event.hxx
+ include/sfx2/evntconf.hxx
+ include/sfx2/fcontnr.hxx
+ include/sfx2/filedlghelper.hxx
++include/sfx2/flatpak.hxx
+ include/sfx2/frame.hxx
+ include/sfx2/frmdescr.hxx
+ include/sfx2/frmhtml.hxx
+@@ -12664,6 +12665,7 @@ sfx2/source/appl/childwin.cxx
+ sfx2/source/appl/childwinimpl.cxx
+ sfx2/source/appl/fileobj.cxx
+ sfx2/source/appl/fileobj.hxx
++sfx2/source/appl/flatpak.cxx
+ sfx2/source/appl/fwkhelper.cxx
+ sfx2/source/appl/helpdispatch.cxx
+ sfx2/source/appl/helpdispatch.hxx
+-- 
+2.20.1
+

--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -42,6 +42,10 @@
                     "disable-fsckobjects": true
                 },
                 {
+                    "type": "patch",
+                    "path": "0001-Support-Preview-in-Web-Browser-in-Flatpak-mode.patch"
+                },
+                {
                     "type": "archive",
                     "url": "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.tar.xz",
                     "sha256": "cebb705dbbe26a41d359b8be08ec066caba4e8686670070ce44bbf2b57ae113f",


### PR DESCRIPTION
...by backporting upstream <https://gerrit.libreoffice.org/plugins/gitiles/core/
+/c61e7b9940cb30800d6f1000727f9cfd5de9fa5e%5E%21> "Support 'Preview in Web
Browser' in Flatpak mode".

This fixes <https://github.com/flathub/org.libreoffice.LibreOffice/issues/85>
"“Preview in Web Browser” does not work in Flatpak version".