### PR TITLE
remove dconf access

### DIFF
--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -599,13 +599,10 @@
         "--socket=pulseaudio",
         "--device=dri",
         "--filesystem=host",
-        "--filesystem=xdg-run/dconf",
-        "--env=DCONF_USER_CONFIG_DIR=.config/dconf",
         "--env=GIO_EXTRA_MODULES=/app/lib/gio/modules",
         "--env=JAVA_HOME=/app/jre",
         "--env=LIBO_FLATPAK=1",
         "--own-name=org.libreoffice.LibreOfficeIpc0",
-        "--talk-name=ca.desrt.dconf",
         "--talk-name=org.gtk.vfs.*"
     ]
 }


### PR DESCRIPTION
See: https://github.com/flathub/flathub/issues/1040
Migration not necessary, libreoffice does not store its settings with dconf