### PR TITLE
Clean krb5 module

### DIFF
--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -37,7 +37,13 @@
             "subdir": "src",
             "config-opts": [
                 "--disable-static",
-                "--disable-rpath"
+                "--disable-rpath",
+                "--sbindir=/app/bin"
+            ],
+            "cleanup": [
+                "/include",
+                "/lib/pkgconfig",
+                "/var"
             ],
             "sources": [
                 {


### PR DESCRIPTION
* put all binaries into /usr/bin instead of splitting them into bin and sbin which doesn't have any purpose in flatpak
* cleanup development files after build is done