### PR TITLE
Add Finnish spell checker and hyphenation. Closes #122.

### DIFF
--- a/foma-installpath.patch
+++ b/foma-installpath.patch
@@ -1,0 +1,17 @@
+--- a/Makefile	2021-06-21 11:41:45.764583598 +0300
++++ foma-0.9.17/Makefile	2021-06-21 11:57:35.945567018 +0300
+@@ -1,4 +1,4 @@
+-prefix = /usr/local
++prefix = /app
+ exec_prefix = $(prefix)
+ libdir = $(exec_prefix)/lib
+ bindir = $(exec_prefix)/bin
+@@ -13,7 +13,7 @@
+ LEXIFACE = flex -8 --prefix=interface
+ LEXCMATRIX = flex -8 --prefix=cmatrix
+ RM = /bin/rm -f
+-LDFLAGS = -lreadline -lz -ltermcap
++LDFLAGS = -lreadline -lz
+ FLOOKUPLDFLAGS = libfoma.a -lz
+ CFLAGS = -O3 -Wall -D_GNU_SOURCE -std=c99 -fvisibility=hidden -fPIC
+ FOMAOBJS = foma.o stack.o iface.o lex.interface.o

--- a/foma-variables.patch
+++ b/foma-variables.patch
@@ -1,0 +1,60 @@
+--- foma-0.9.18/foma.h	2015-06-12 22:38:57.000000000 +0300
++++ b/foma.h	2021-06-21 12:12:55.739363135 +0300
+@@ -24,8 +24,8 @@
+ #define PROMPT_MAIN 0 /* Regular prompt */
+ #define PROMPT_A 1    /* Apply prompt   */
+ 
+-struct defined_networks   *g_defines;
+-struct defined_functions  *g_defines_f;
++extern struct defined_networks   *g_defines;
++extern struct defined_functions  *g_defines_f;
+ 
+ /** User stack */
+ struct stack_entry {
+--- foma-0.9.18/foma.c	2015-06-13 06:24:13.000000000 +0300
++++ b/foma.c	2021-06-21 12:14:59.764143662 +0300
+@@ -24,6 +24,10 @@
+ #include <readline/readline.h>
+ #include "foma.h"
+ 
++struct defined_networks   *g_defines;
++struct defined_functions  *g_defines_f;
++
++
+ /* Front-end behavior variables */
+ int pipe_mode = 0;
+ int quiet_mode = 0;
+--- foma-0.9.18/determinize.c	2015-06-13 06:24:13.000000000 +0300
++++ b/determinize.c	2021-06-21 12:13:56.387744770 +0300
+@@ -59,12 +59,12 @@
+     unsigned int set_offset;
+ };
+ 
+-struct trans_list {
++static struct trans_list {
+     int inout;
+     int target;
+ } *trans_list;
+ 
+-struct trans_array {
++static struct trans_array {
+     struct trans_list *transitions;
+     unsigned int size;
+     unsigned int tail;
+--- foma-0.9.18/minimize.c	2015-06-13 06:24:13.000000000 +0300
++++ b/minimize.c	2021-06-21 12:13:35.157611165 +0300
+@@ -66,12 +66,12 @@
+   _Bool index;
+ };
+ 
+-struct trans_list {
++static struct trans_list {
+     int inout;
+     int source;
+ } *trans_list;
+ 
+-struct trans_array {
++static struct trans_array {
+     struct trans_list *transitions;
+     unsigned int size;
+     unsigned int tail;

--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -699,6 +699,121 @@
                 "make cmd cmd='$(SRCDIR)/solenv/bin/assemble-flatpak.sh'",
                 "printf '<?xml version=\"1.0\"?>\\n<oor:data xmlns:xs=\"http://www.w3.org/2001/XMLSchema\" xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\" xmlns:oor=\"http://openoffice.org/2001/registry\"><dependency file=\"main\"/><oor:component-data oor:name=\"Common\" oor:package=\"org.openoffice.Office\"><node oor:name=\"Misc\"><prop oor:name=\"UseOpenCL\"><value>false</value></prop></node></oor:component-data></oor:data>' >/app/libreoffice/share/registry/flatpak.xcd"
             ]
+        },
+        {
+            "name": "libsigc++",
+            "buildsystem": "autotools",
+            "config-opts": [ "--disable-documentation"  ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://deb.debian.org/debian/pool/main/libs/libsigc++-2.0/libsigc++-2.0_2.10.1.orig.tar.xz",
+                    "sha256": "576c763a81870f36d1cf582f3a9042fd41c9be874f27be61505d5be1d7240b37"
+                }
+            ]
+        },
+        {
+            "name": "glibmm",
+            "buildsystem": "autotools",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://deb.debian.org/debian/pool/main/g/glibmm2.4/glibmm2.4_2.58.0.orig.tar.xz",
+                    "sha256": "c954425f729788503f51eea3cd9dc23d9eb0909f0f72a9e8bb9027a20f8d8c05"
+                }
+            ]
+        },
+        {
+            "name": "libxml++",
+            "buildsystem": "autotools",
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "http://deb.debian.org/debian/pool/main/libx/libxml++2.6/libxml++2.6_2.40.1.orig.tar.xz",
+                    "sha256": "4ad4abdd3258874f61c2e2a41d08e9930677976d303653cd1670d3e9f35463e9"
+                }
+            ]
+        },
+        {
+            "name": "hfst-ospell",
+            "buildsystem": "simple",
+            "build-commands": [ "autoreconf --install",
+                                "./configure --prefix=/app",
+                                "make",
+                                "make install" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://github.com/hfst/hfst-ospell/releases/download/v0.5.2/hfst-ospell-0.5.2.tar.bz2",
+                    "sha256": "ab9ccf3c2165c0efd8dd514e0bf9116e86a8a079d712c0ed6c2fabf0052e9aa4"
+                }
+            ]
+        },
+        {
+            "name": "libvoikko",
+            "buildsystem": "simple",
+            "build-commands": [ "./configure --prefix=/app --with-dictionary-path=/app/lib/voikko",
+                                "make",
+                                "make install",
+                                "mkdir -p /app/lib/python3.8/site-packages",
+                                "cd python && python3 ./setup.py install --prefix=/app" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://www.puimula.org/voikko-sources/libvoikko/libvoikko-4.3.1.tar.gz",
+                    "sha256": "368240d4cfa472c2e2c43dc04b63e6464a3e6d282045848f420d0f7a6eb09a13"
+                },
+                {
+                    "type": "patch",
+                    "path": "voikkopython.patch"
+                }
+            ]
+        },
+        {
+            "name": "foma",
+            "buildsystem": "simple",
+            "build-commands": [ "make", "make install" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://bitbucket.org/mhulden/foma/downloads/foma-0.9.18.tar.gz",
+                    "sha256": "cb380f43e86fc7b3d4e43186db3e7cff8f2417e18ea69cc991e466a3907d8cbd"
+                },
+                {
+                    "type": "patch",
+                    "path": "foma-installpath.patch"
+                },
+                {
+                    "type": "patch",
+                    "path": "foma-variables.patch"
+                }
+            ]
+        },
+        {
+            "name": "voikko-fi",
+            "buildsystem": "simple",
+            "build-commands": [ "make vvfst", "make vvfst-install DESTDIR=/app/lib/voikko" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://www.puimula.org/voikko-sources/voikko-fi/voikko-fi-2.4.tar.gz",
+                    "sha256": "320b2d4e428f6beba9d0ab0d775f8fbe150284fbbafaf3e5afaf02524cee28cc"
+                }
+            ]
+        },
+        {
+            "name": "libreoffice-voikko",
+            "buildsystem": "simple",
+            "build-commands": [ "make oxt",
+                                "mkdir -p /app/libreoffice/share/extensions/voikko",
+                                "unzip -d /app/libreoffice/share/extensions/voikko build/voikko.oxt" ],
+            "sources": [
+                {
+                    "type": "archive",
+                    "url": "https://www.puimula.org/voikko-sources/libreoffice-voikko/libreoffice-voikko-5.0.tar.gz",
+                    "sha256": "8322b58d83eb6e1398d6914885d88a2ee08c8dd2fc2b72d75fba8fe83eefbe38"
+                }
+            ]
         }
     ],
     "add-extensions": {

--- a/voikkopython.patch
+++ b/voikkopython.patch
@@ -1,0 +1,10 @@
+--- /dev/null
++++ libvoikko-4.3.1/python/setup.py
+@@ -0,0 +1,7 @@
++from setuptools import setup
++
++setup(
++    name='voikko',
++    py_modules=['libvoikko'],
++    long_description='Finnish hyphenation and spellchecking.'
++)


### PR DESCRIPTION
This adds the Voikko extension to the Flathub version of LO. This extension can _not_ be installed from the extension manager because it requires that the Voikko libraries and data files are built and installed on the system. Trying to do so anyway will make LO Writer crash immediately on startup.

To validate that the installation is working do the following:

- launch LO
- open extension manager
- the Voikko extension should be in the list of installed extensions
- click on "options"
- if the popup window has Finnish in the dictionary dropdown, everything should be fine