### PR TITLE
Add an org.libreoffice.LibreOffice.BundledExtension extension point

### DIFF
--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -702,6 +702,12 @@
         }
     ],
     "add-extensions": {
+        "org.libreoffice.LibreOffice.BundledExtension": {
+            "directory": "libreoffice/share/extensions",
+            "subdirectories": true,
+            "no-autodownload": true,
+            "autodelete": true
+        },
         "org.libreoffice.LibreOffice.Help": {
             "directory": "libreoffice/help",
             "bundle": true,


### PR DESCRIPTION
The motivation is to try and turn
<https://github.com/flathub/org.libreoffice.LibreOffice/pull/155> "Add Finnish
spell checker and hyphenation. Closes #122." into such an extension, instead of
having it always installed (and burdening org.libreoffice.LibreOffice.json with
another eight additional modules).