### PR TITLE
Add global-menu support for KDE and unity

### DIFF
--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -720,6 +720,7 @@
         "--env=JAVA_HOME=/app/jre",
         "--env=LIBO_FLATPAK=1",
         "--own-name=org.libreoffice.LibreOfficeIpc0",
-        "--talk-name=org.gtk.vfs.*"
+        "--talk-name=org.gtk.vfs.*",
+        "--talk-name=com.canonical.AppMenu.Registrar"
     ]
 }


### PR DESCRIPTION
Add required talk permission to support global menu into unity desktop and in KDE (when global-menu widget is used).