### PR TITLE
Adding access to gtk-3.0 config

### DIFF
--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -722,6 +722,7 @@
         "--socket=wayland",
         "--socket=pulseaudio",
         "--device=dri",
+        "--filesystem=xdg-config/gtk-3.0",
         "--filesystem=host",
         "--env=GIO_EXTRA_MODULES=/app/lib/gio/modules",
         "--env=JAVA_HOME=/app/jre",


### PR DESCRIPTION
Mainly to give access to bookmarks for the file picker. Fixes #111.