### PR TITLE
Change socket to fallback-x11 to fix "Unsafe" warning

### DIFF
--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -718,7 +718,7 @@
     "finish-args": [
         "--share=network",
         "--share=ipc",
-        "--socket=x11",
+        "--socket=fallback-x11",
         "--socket=wayland",
         "--socket=pulseaudio",
         "--device=dri",


### PR DESCRIPTION
Using `--socket=x11` results in GNOME Software showing the app as "Unsafe. Uses a legacy windowing system." Changing this to `--socket=fallback-x11` lets app run on Wayland, but can use X11 if Wayland not available