### PR TITLE
Adding xdg-run/gvfsd

### DIFF
--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -723,6 +723,7 @@
         "--socket=pulseaudio",
         "--device=dri",
         "--filesystem=xdg-config/gtk-3.0",
+        "--filesystem=xdg-run/gvfsd",
         "--filesystem=host",
         "--env=GIO_EXTRA_MODULES=/app/lib/gio/modules",
         "--env=JAVA_HOME=/app/jre",


### PR DESCRIPTION
Necessary to use the GIO APIs to list and access non-native files using the GIO APIs, using URLs rather than FUSE paths.

Solves #182.