### PR TITLE
Update GVFS, Kerberos5, Apache Ant and OpenJDK Flathub Extension

### DIFF
--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -64,8 +64,8 @@
                 },
                 {
                     "type": "archive",
-                    "url": "https://dlcdn.apache.org//ant/binaries/apache-ant-1.10.13-bin.zip",
-                    "sha512": "347e964db73d1f8e9fe110f135625920e09c8c9997e9950c405cfeec60b70750044a91ef0535d76d6f8e023de0788f2619be76fd91b7a80be9a6b569a16cc3e8",
+                    "url": "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.13-bin.tar.xz",
+                    "sha512": "26e56bf670c22c8093fe51ec952fa51e813b1ab4200cb09fcd68fa291c5f6f626d7c6a42b4d3358b38111466e249d4bc6089b8c4093383759d6f8a08d39bc32d",
                     "dest": "ant"
                 },
                 {

--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -64,7 +64,7 @@
                 },
                 {
                     "type": "archive",
-                    "url": "apache-ant-1.10.9-bin.tar.xz",
+                    "url": "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.9-bin.tar.xz",
                     "sha256": "42f12ea7dc854b69aac0bd05c5767252dddd297888503e69b8aae0a1dc791cf5",
                     "dest": "ant"
                 },

--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -4,7 +4,7 @@
     "runtime-version": "22.08",
     "sdk": "org.freedesktop.Sdk",
     "sdk-extensions": [
-        "org.freedesktop.Sdk.Extension.openjdk11"
+        "org.freedesktop.Sdk.Extension.openjdk17"
     ],
     "command": "libreoffice",
     "modules": [
@@ -12,7 +12,7 @@
             "name": "openjdk",
             "buildsystem": "simple",
             "build-commands": [
-                "/usr/lib/sdk/openjdk11/install.sh"
+                "/usr/lib/sdk/openjdk17/install.sh"
             ]
         },
         {

--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -64,8 +64,8 @@
                 },
                 {
                     "type": "archive",
-                    "url": "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.9-bin.tar.xz",
-                    "sha256": "42f12ea7dc854b69aac0bd05c5767252dddd297888503e69b8aae0a1dc791cf5",
+                    "url": "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.tar.xz",
+                    "sha256": "cebb705dbbe26a41d359b8be08ec066caba4e8686670070ce44bbf2b57ae113f",
                     "dest": "ant"
                 },
                 {

--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -27,8 +27,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://gitlab.gnome.org/GNOME/gvfs/-/archive/2a3a35adc4e1b7a3195033b072917abbb97a9f4e/gvfs-2a3a35adc4e1b7a3195033b072917abbb97a9f4e.tar.gz",
-                    "sha256": "1e1bbe249be35b7b864a2dad707188e69b3cef1cd66a24df6e83b24a4c329c44"
+                    "url": "https://gitlab.gnome.org/GNOME/gvfs/-/archive/1.50.4/gvfs-1.50.4.tar.gz",
+                    "sha256": "c67bba49c5b1dbe0b8b8f53b45eab545f6a6ce36fcdf3c11ac92464732b60ea5"
                 }
             ]
         },

--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -49,7 +49,7 @@
                 {
                     "type": "archive",
                     "url": "https://kerberos.org/dist/krb5/1.20/krb5-1.20.1.tar.gz",
-                    "sha256": "704aed49b19eb5a7178b34b2873620ec299db08752d6a8574f95d41879ab88517"
+                    "sha256": "704aed49b19eb5a7178b34b2873620ec299db08752d6a8574f95d41879ab8851"
                 }
             ]
         },

--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -48,8 +48,8 @@
             "sources": [
                 {
                     "type": "archive",
-                    "url": "https://kerberos.org/dist/krb5/1.16/krb5-1.16.2.tar.gz",
-                    "sha256": "9f721e1fe593c219174740c71de514c7228a97d23eb7be7597b2ae14e487f027"
+                    "url": "https://kerberos.org/dist/krb5/1.20/krb5-1.20.1.tar.gz",
+                    "sha256": "704aed49b19eb5a7178b34b2873620ec299db08752d6a8574f95d41879ab88517"
                 }
             ]
         },
@@ -64,8 +64,8 @@
                 },
                 {
                     "type": "archive",
-                    "url": "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.tar.xz",
-                    "sha256": "cebb705dbbe26a41d359b8be08ec066caba4e8686670070ce44bbf2b57ae113f",
+                    "url": "apache-ant-1.10.9-bin.tar.xz",
+                    "sha256": "42f12ea7dc854b69aac0bd05c5767252dddd297888503e69b8aae0a1dc791cf5",
                     "dest": "ant"
                 },
                 {

--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -64,8 +64,8 @@
                 },
                 {
                     "type": "archive",
-                    "url": "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.5-bin.tar.xz",
-                    "sha256": "cebb705dbbe26a41d359b8be08ec066caba4e8686670070ce44bbf2b57ae113f",
+                    "url": "https://dlcdn.apache.org//ant/binaries/apache-ant-1.10.13-bin.zip",
+                    "sha512": "347e964db73d1f8e9fe110f135625920e09c8c9997e9950c405cfeec60b70750044a91ef0535d76d6f8e023de0788f2619be76fd91b7a80be9a6b569a16cc3e8",
                     "dest": "ant"
                 },
                 {


### PR DESCRIPTION
Update GVFS to the newest release 1.50.4 
Apache ant to 1.10.9.
Kerberos 5 to 20.1
Use new OpenJDK 17 LTS version instead 11