### PR TITLE
Fix broken LibreOffice test

### DIFF
--- a/0001-Backport-fix-for-test-that-started-to-fail-with-libx.patch
+++ b/0001-Backport-fix-for-test-that-started-to-fail-with-libx.patch
@@ -1,0 +1,76 @@
+From 428e59f229fac1470b7c1cb240f42149843f5409 Mon Sep 17 00:00:00 2001
+From: Stephan Bergmann <sbergman@redhat.com>
+Date: Wed, 26 Apr 2023 11:34:42 +0200
+Subject: [PATCH] Backport fix for test that started to fail with libxml2
+ 2.10.4
+
+This is a backport of the relevant part of
+91fcb290ab0cc26a8ec584da9610f553fd27ac97 "libxml2: upgrade to release 2.10.4"
+from libreoffice-7-5-3.
+
+I had seen builds of LibreOffice 7.5.2 on Flathub start to fail now after
+<https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/commit/f8fe772fe3134e95d8d0a17a225a0453bbbc1e86>
+"Update elements/components/libxml2.bst to v2.10.4-0", with the same symptoms as
+described for the backported fix, e.g.
+(<https://buildbot.flathub.org/#/builders/26/builds/4650>),
+
+> xmltesttools.cxx:188:Assertion
+> Test name: testReqIfTable::Import_Export
+> equality assertion failed
+> - Expected: 1
+> - Actual  : 0
+> - In <file:///tmp/lu6859867e7nps.tmp>, XPath '/html/body/div/table/tr/th' number of nodes is incorrect
+> Failures !!!
+> Run: 81   Failure total: 1   Failures: 1   Errors: 0
+> Error: a unit test failed, please do one of:
+> make CppunitTest_sw_htmlexport CPPUNITTRACE="gdb --args"
+>     # for interactive debugging on Linux
+> make CppunitTest_sw_htmlexport VALGRIND=memcheck
+>     # for memory checking
+> make CppunitTest_sw_htmlexport DEBUGCPPUNIT=TRUE
+>     # for exception catching
+> You can limit the execution to just one particular test by:
+> make CPPUNIT_TEST_NAME="testXYZ" ...above mentioned params...
+> make[1]: *** [/run/build/libreoffice/solenv/gbuild/CppunitTest.mk:121: /run/build/libreoffice/workdir/CppunitTest/sw_htmlexport.test] Error 1
+
+Change-Id: I9ffc01f8b8af1f43cf0d65be404787e300655c02
+---
+ sw/qa/extras/htmlexport/htmlexport.cxx | 16 ++++++++++++----
+ 1 file changed, 12 insertions(+), 4 deletions(-)
+
+diff --git a/sw/qa/extras/htmlexport/htmlexport.cxx b/sw/qa/extras/htmlexport/htmlexport.cxx
+index a8cc4d2cef04..d78e35c1413a 100644
+--- a/sw/qa/extras/htmlexport/htmlexport.cxx
++++ b/sw/qa/extras/htmlexport/htmlexport.cxx
+@@ -777,16 +777,24 @@ DECLARE_HTMLEXPORT_TEST(testReqIfJpgImg, "reqif-jpg-img.xhtml")
+ 
+ DECLARE_HTMLEXPORT_TEST(testReqIfTable, "reqif-table.xhtml")
+ {
+-    htmlDocUniquePtr pDoc = parseHtml(maTempFile);
++    SvMemoryStream aStream;
++    WrapReqifFromTempFile(aStream);
++    xmlDocUniquePtr pDoc = parseXmlStream(&aStream);
+     CPPUNIT_ASSERT(pDoc);
+ 
+     // <div> was missing, so the XHTML fragment wasn't a valid
+     // xhtml.BlkStruct.class type anymore.
+-    assertXPath(pDoc, "/html/body/div/table/tr/th", 1);
++    assertXPath(pDoc,
++                "/reqif-xhtml:html/reqif-xhtml:div/reqif-xhtml:table/reqif-xhtml:tr/reqif-xhtml:th",
++                1);
+     // Make sure that the cell background is not written using CSS.
+-    assertXPathNoAttribute(pDoc, "/html/body/div/table/tr/th", "style");
++    assertXPathNoAttribute(
++        pDoc, "/reqif-xhtml:html/reqif-xhtml:div/reqif-xhtml:table/reqif-xhtml:tr/reqif-xhtml:th",
++        "style");
+     // The attribute was present, which is not valid in reqif-xhtml.
+-    assertXPathNoAttribute(pDoc, "/html/body/div/table/tr/th", "bgcolor");
++    assertXPathNoAttribute(
++        pDoc, "/reqif-xhtml:html/reqif-xhtml:div/reqif-xhtml:table/reqif-xhtml:tr/reqif-xhtml:th",
++        "bgcolor");
+ }
+ 
+ DECLARE_HTMLEXPORT_TEST(testReqIfTable2, "reqif-table2.odt")
+-- 
+2.40.0
+

--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -63,6 +63,11 @@
                     "disable-fsckobjects": true
                 },
                 {
+                    "type": "patch",
+                    "path": "0001-Backport-fix-for-test-that-started-to-fail-with-libx.patch",
+                    "use-git": true
+                },
+                {
                     "type": "archive",
                     "url": "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.13-bin.tar.xz",
                     "sha512": "26e56bf670c22c8093fe51ec952fa51e813b1ab4200cb09fcd68fa291c5f6f626d7c6a42b4d3358b38111466e249d4bc6089b8c4093383759d6f8a08d39bc32d",


### PR DESCRIPTION
...that started to fail now due to
<https://gitlab.com/freedesktop-sdk/freedesktop-sdk/-/commit/f8fe772fe3134e95d8d0a17a225a0453bbbc1e86> "Update elements/components/libxml2.bst to v2.10.4-0" (see the commit message in the added 0001-Backport-fix-for-test-that-started-to-fail-with-libx.patch for details)