### PR TITLE
No longer append appdata for components to flatpak's metainfo

### DIFF
--- a/0001-No-longer-append-appdata-for-components-to-flatpak-s.patch
+++ b/0001-No-longer-append-appdata-for-components-to-flatpak-s.patch
@@ -1,0 +1,102 @@
+From 56b4e4e3fabe3ce13c6900706d452a0261306ff3 Mon Sep 17 00:00:00 2001
+From: Stephan Bergmann <sbergman@redhat.com>
+Date: Thu, 8 Jun 2023 13:08:14 +0200
+Subject: [PATCH] No longer append appdata for components to flatpak's metainfo
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+This had originally been added with
+<https://github.com/flathub/org.libreoffice.LibreOffice/commit/945f6caad87658b1df1e8918bd5f64939058ab7f>
+"clean up desktop integration", see its part "append the appdata for the
+separate apps (Base, Draw, etc) to the appdata XML we export for Flatpak, so
+they are visible in software centers etc".  But it now started to cause Flathub
+builds (like <https://buildbot.flathub.org/#/builders/14/builds/3985>) to fail
+its "Check for right id in AppStream xml" step, and reportedly "the problem is
+there are multiple components in the metainfo file and I'm not sure it's
+allowed"
+(<https://matrix.to/#/!RfXaBjokqHAbzZrgHz:matrix.org/$jWhob-a4LEH-e_TXsJwGWNfMYLF1kcWpXV_oW982ZpI?via=matrix.org&via=gnome.org&via=kde.org>).
+
+The solution appears to be to just remove that again
+(<https://matrix.to/#/!RfXaBjokqHAbzZrgHz:matrix.org/$Yrzf_ZjJxBgUVs6kuP_10Tneu1t1wKQJCM_SC1vNHC4?via=matrix.org&via=gnome.org&via=kde.org>):
+
+> I think maybe the problem was from the times that GNOME Software was also
+> moonlighting as a menu editor
+> that without Flatpak providing the metainfo for LibreOffice's different
+> desktop launchers, they were invisible in GNOME Software, which meant you
+> couldn't add/remove them to menus or the desktop
+> but since then GNOME just shows all of the launchers, and menu editing /
+> categories mostly died or sank to the bottom of the 1990s ocean
+> so maybe this is a non-problem
+[...]
+> ah ok
+> ah so they don't show any more 🤣
+
+So remove the now-unused solenv/bin/assemble-flatpak-appdata-step2.sh and
+consequently rename the sole remaining
+solenv/bin/assemble-flatpak-appdata-step1.sh to just
+solenv/bin/assemble-flatpak-appdata.sh.
+
+Change-Id: I3d3fef502f2114274a856102b77edafdd0ecac83
+---
+ solenv/bin/assemble-flatpak-appdata-step2.sh  | 26 -------------------
+ ...a-step1.sh => assemble-flatpak-appdata.sh} |  0
+ solenv/bin/assemble-flatpak.sh                |  4 +--
+ 3 files changed, 1 insertion(+), 29 deletions(-)
+ delete mode 100755 solenv/bin/assemble-flatpak-appdata-step2.sh
+ rename solenv/bin/{assemble-flatpak-appdata-step1.sh => assemble-flatpak-appdata.sh} (100%)
+
+diff --git a/solenv/bin/assemble-flatpak-appdata-step2.sh b/solenv/bin/assemble-flatpak-appdata-step2.sh
+deleted file mode 100755
+index 4f06e6b19148..000000000000
+--- a/solenv/bin/assemble-flatpak-appdata-step2.sh
++++ /dev/null
+@@ -1,26 +0,0 @@
+-#! /bin/bash
+-#
+-# This file is part of the LibreOffice project.
+-#
+-# This Source Code Form is subject to the terms of the Mozilla Public
+-# License, v. 2.0. If a copy of the MPL was not distributed with this
+-# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+-#
+-
+-# Part of solenv/bin/assemble-flatpak.sh that is shared with a downstream mechanism of building a
+-# Flatpak from a Fedora libreoffice.spec file.
+-#
+-# Arguments:
+-# $1  pathname, ending in a slash, of the directory containing the source libreoffice-*.appdata.xml
+-#     files
+-# $2  pathname, ending in a slash, of the directory containing the target
+-#     org.libreoffice.LibreOffice.appdata.xml file
+-
+-set -e
+-
+-# append the appdata for the different components
+-for i in "${1?}"libreoffice-*.appdata.xml
+-do
+-  sed "1 d; s/<id>libreoffice-/<id>org.libreoffice.LibreOffice./" "$i" \
+-    >>"${2?}"org.libreoffice.LibreOffice.appdata.xml
+-done
+diff --git a/solenv/bin/assemble-flatpak-appdata-step1.sh b/solenv/bin/assemble-flatpak-appdata.sh
+similarity index 100%
+rename from solenv/bin/assemble-flatpak-appdata-step1.sh
+rename to solenv/bin/assemble-flatpak-appdata.sh
+diff --git a/solenv/bin/assemble-flatpak.sh b/solenv/bin/assemble-flatpak.sh
+index 9991a0d0d71c..8d45da6cc1df 100755
+--- a/solenv/bin/assemble-flatpak.sh
++++ b/solenv/bin/assemble-flatpak.sh
+@@ -62,9 +62,7 @@ do
+ done
+ 
+ mkdir -p /app/share/appdata
+-"${SRCDIR?}"/solenv/bin/assemble-flatpak-appdata-step1.sh /app/share/appdata/ 1
+-"${SRCDIR?}"/solenv/bin/assemble-flatpak-appdata-step2.sh "${PREFIXDIR?}"/share/metainfo/ \
+- /app/share/appdata/
++"${SRCDIR?}"/solenv/bin/assemble-flatpak-appdata.sh /app/share/appdata/ 1
+ 
+ ## see <https://github.com/flatpak/flatpak/blob/master/app/
+ ## flatpak-builtins-build-finish.c> for further places where build-finish would
+-- 
+2.40.1
+

--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -63,6 +63,11 @@
                     "disable-fsckobjects": true
                 },
                 {
+                    "type": "patch",
+                    "path": "0001-No-longer-append-appdata-for-components-to-flatpak-s.patch",
+                    "use-git": true
+                },
+                {
                     "type": "archive",
                     "url": "https://archive.apache.org/dist/ant/binaries/apache-ant-1.10.13-bin.tar.xz",
                     "sha512": "26e56bf670c22c8093fe51ec952fa51e813b1ab4200cb09fcd68fa291c5f6f626d7c6a42b4d3358b38111466e249d4bc6089b8c4093383759d6f8a08d39bc32d",


### PR DESCRIPTION
This had originally been added with
<https://github.com/flathub/org.libreoffice.LibreOffice/commit/945f6caad87658b1df1e8918bd5f64939058ab7f> "clean up desktop integration", see its part "append the appdata for the separate apps (Base, Draw, etc) to the appdata XML we export for Flatpak, so they are visible in software centers etc".  But it now started to cause Flathub builds (like <https://buildbot.flathub.org/#/builders/14/builds/3985>) to fail its "Check for right id in AppStream xml" step, and reportedly "the problem is there are multiple components in the metainfo file and I'm not sure it's allowed"
(<https://matrix.to/#/!RfXaBjokqHAbzZrgHz:matrix.org/$jWhob-a4LEH-e_TXsJwGWNfMYLF1kcWpXV_oW982ZpI?via=matrix.org&via=gnome.org&via=kde.org>).

The solution appears to be to just remove that again (<https://matrix.to/#/!RfXaBjokqHAbzZrgHz:matrix.org/$Yrzf_ZjJxBgUVs6kuP_10Tneu1t1wKQJCM_SC1vNHC4?via=matrix.org&via=gnome.org&via=kde.org>):

> I think maybe the problem was from the times that GNOME Software was also
> moonlighting as a menu editor
> that without Flatpak providing the metainfo for LibreOffice's different
> desktop launchers, they were invisible in GNOME Software, which meant you
> couldn't add/remove them to menus or the desktop
> but since then GNOME just shows all of the launchers, and menu editing /
> categories mostly died or sank to the bottom of the 1990s ocean
> so maybe this is a non-problem
[...]
> ah ok
> ah so they don't show any more 🤣