### PR TITLE
Switch to KDE Platform/SDK and Building with KF5/QT5 VCL's Backends

### DIFF
--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -1,8 +1,8 @@
 {
     "id": "org.libreoffice.LibreOffice",
-    "runtime": "org.freedesktop.Platform",
+    "runtime": "org.kde.Platform",
     "runtime-version": "22.08",
-    "sdk": "org.freedesktop.Sdk",
+    "sdk": "org.kde.Sdk2",
     "sdk-extensions": [
         "org.freedesktop.Sdk.Extension.openjdk17"
     ],
@@ -58,6 +58,20 @@
                     }
                 }
             ]
+        },
+        {    
+            "name": "autoconf",
+            "config-opts": [
+             "--program-suffix=-2.71"
+            ],
+            "cleanup": [
+               "*"
+            ],
+            {
+              "type": "archive",
+              "url": "https://ftp.gnu.org/gnu/autoconf/autoconf-2.71.tar.gz",
+              "sha256": "431075ad0bf529ef13cb41e9042c542381103e80015686222b8a9d4abef42a1c",
+            }
         },
         {
             "name": "krb5",

--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -710,7 +710,7 @@
             ],
             "buildsystem": "simple",
             "build-commands": [
-                "./autogen.sh --prefix=/run/build/libreoffice/inst --with-distro=LibreOfficeFlatpak --with-gdrive-client-id=280867422816-9jc83t6phkfb2q8p94dtk8kr5fa8af3r.apps.googleusercontent.com --with-gdrive-client-secret=Hnzikj7HqdqsUYLru4jmFo1p",
+                "./autogen.sh --prefix=/run/build/libreoffice/inst --with-distro=LibreOfficeFlatpak --enable-kf5 --enable-qt5 --with-gdrive-client-id=280867422816-9jc83t6phkfb2q8p94dtk8kr5fa8af3r.apps.googleusercontent.com --with-gdrive-client-secret=Hnzikj7HqdqsUYLru4jmFo1p",
                 "make check",
                 "make distro-pack-install",
                 "make cmd cmd='$(SRCDIR)/solenv/bin/assemble-flatpak.sh'",


### PR DESCRIPTION
This work is based on the @CarlSchwan, in some parts is the same thing that older Pull Request use but with KF5/QT5 VCL's backend, this add autoconf to build.
