### PR TITLE
Use KDE SDK, Runtime and KF6

### DIFF
--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -817,7 +817,7 @@
                 }
              },
             "build-commands": [
-                "./autogen.sh --prefix=/run/build/libreoffice/inst --with-distro=LibreOfficeFlatpak --includedir=/usr/include --enable-kf6 --enable-qt6 --enable-gtk3 --with-gdrive-client-id=280867422816-9jc83t6phkfb2q8p94dtk8kr5fa8af3r.apps.googleusercontent.com --with-gdrive-client-secret=Hnzikj7HqdqsUYLru4jmFo1p",
+                "./autogen.sh --prefix=/run/build/libreoffice/inst --with-distro=LibreOfficeFlatpak --includedir=/usr/include --with-system-headers --enable-kf6 --enable-qt6 --enable-gtk3 --with-gdrive-client-id=280867422816-9jc83t6phkfb2q8p94dtk8kr5fa8af3r.apps.googleusercontent.com --with-gdrive-client-secret=Hnzikj7HqdqsUYLru4jmFo1p",
                 "make check",
                 "make distro-pack-install",
                 "make cmd cmd='$(SRCDIR)/solenv/bin/assemble-flatpak.sh'",


### PR DESCRIPTION
> [!IMPORTANT]  
> This needs testing, please do not mark as ready ***yet***.

Uses changes from:

https://github.com/flathub/org.libreoffice.LibreOffice/pull/253 (Switch to KDE Runtime/SDK and Building with KF5/QT5 VCL's Backends by @EliasOfWaffle, based on @CarlSchwan's PR)