### PR TITLE
Allow accessing cups for printing

### DIFF
--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -882,6 +882,7 @@
         "--socket=fallback-x11",
         "--socket=wayland",
         "--socket=pulseaudio",
+        "--socket=cups",
         "--device=dri",
         "--filesystem=xdg-config/gtk-3.0",
         "--filesystem=xdg-config/fontconfig:ro",


### PR DESCRIPTION
This is necessary on some systems.

 Fixes https://github.com/flathub/org.libreoffice.LibreOffice/issues/307