### PR TITLE
Remove com.canonical.AppMenu.Registrar

### DIFF
--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -899,6 +899,6 @@
         "--env=JAVA_HOME=/app/jre",
         "--env=LIBO_FLATPAK=1",
         "--own-name=org.libreoffice.LibreOfficeIpc0",
-        "--talk-name=org.gtk.vfs.*",
+        "--talk-name=org.gtk.vfs.*"
     ]
 }


### PR DESCRIPTION
This adds the workaround mentioned in #234. Without that LibreOffice is missing its menu and can't be used under certain circumstances. This should be reverted as soon as there is a solution for #234.