### PR TITLE
GTK4 VCL enablement

### DIFF
--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -20,8 +20,7 @@
             "buildsystem": "meson",
             "config-opts": [
                 "-Dbuild-examples=false",
-                "-Dbuild-demos=false",
-                "-Dcloudproviders=enabled"
+                "-Dbuild-demos=false"
             ],
             "sources": [
                 {


### PR DESCRIPTION
This PR enables LibreOffice's GTK4 VCL backend. As the FDO runtime has no GTK4, the GNOME runtime is used