### PR TITLE
Make gtk-config dir as read-only

### DIFF
--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -143,7 +143,7 @@
         "--socket=pulseaudio",
         "--socket=cups",
         "--device=dri",
-        "--filesystem=xdg-config/gtk-3.0",
+        "--filesystem=xdg-config/gtk-3.0:ro",
         "--filesystem=xdg-config/fontconfig:ro",
         "--filesystem=xdg-run/gvfsd",
         "--filesystem=host",


### PR DESCRIPTION
Write access shouldn't be needed there, see https://github.com/flathub/org.gtk.Gtk3theme.Breeze#workarounds