### PR TITLE
finish-args: Add --filesystem=xdg-run/doc

### DIFF
--- a/org.libreoffice.LibreOffice.json
+++ b/org.libreoffice.LibreOffice.json
@@ -145,6 +145,7 @@
         "--device=dri",
         "--filesystem=xdg-config/gtk-3.0",
         "--filesystem=xdg-config/fontconfig:ro",
+        "--filesystem=xdg-run/doc",
         "--filesystem=xdg-run/gvfsd",
         "--filesystem=host",
         "--env=GIO_EXTRA_MODULES=/app/lib/gio/modules",


### PR DESCRIPTION
This fixes file opening from GNOME's overview search for Fedora Silverblue users.